### PR TITLE
Disable key verification

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,7 @@ install:
 # Latex requirements
   - PATH=$HOME/texlive/bin/x86_64-linux:$PATH
   - tlmgr option repository ctan
-  - tlmgr update --self
+  - tlmgr update --verify-repo=none --self
   - tlmgr install combelow
   - tlmgr install babel-french
   - tlmgr install babel-german


### PR DESCRIPTION
It expired. And there's no information available how to update. And the risk is low (don't say that loud).