### PR TITLE
Harmonize capitals in headings and rename some sections

### DIFF
--- a/documentation/how-to/attributes-form.en.md
+++ b/documentation/how-to/attributes-form.en.md
@@ -1,8 +1,8 @@
 ---
-title: Attribute Form
+title: Attribute form
 ---
 
-# Attribute Form
+# Attribute form
 
 QField creates forms similar to, but not equal to QGIS.
 The field widgets from QGIS are supported on a best effort basis and optimized for the mobile use.
@@ -33,7 +33,7 @@ The *editable* flag of fields is respected.
 QField offers a much more fine-grained control over the last used values
 and ignores the QGIS setting.
 
-### Suppress Attribute Form
+### Suppress attribute form
 
 The setting *suppress attribute form* is directly applied to the
 QField form.

--- a/documentation/how-to/bookmarks.md
+++ b/documentation/how-to/bookmarks.md
@@ -6,7 +6,7 @@ title: Bookmarks
 
 QField allows you to save and display bookmarks that will be remembered across sessions and projects.
 
-## Viewing Bookmarks
+## Viewing bookmarks
 :material-tablet-android:{ .device-icon } Fieldwork
 
 By default, QField will display bookmarks as marker overlays over the map. User-added bookmarks are displayed across all projects and datasets.
@@ -23,7 +23,7 @@ QField also offers a setting to toggle off the displaying of bookmarks, which ca
 
 !![](../assets/images/bookmarks-toggle.png)
 
-## Adding Bookmarks
+## Adding bookmarks
 :material-tablet-android:{ .device-icon } Fieldwork
 
 To add a new bookmark, simply tap and hold any part of the map and select the *Add Bookmark* action within the popped up menu.
@@ -41,6 +41,6 @@ It is also possible to add a bookmark at the current device's location when posi
 !!! note
     When adding a bookmark, the current map scale is taken into consideration to save an extent centered around the tapped coordination or current location. This allows you to determine the extent that will be used when double-tapping on a bookmark marker or selecting a bookmark item in the search bar.
 
-## Project Bookmarks
+## Project bookmarks
 
 QField can display and search for project-embedded bookmarks. The addition and management of such bookmarks is done [in QGIS itself](https://docs.qgis.org/latest/en/docs/user_manual/introduction/general_tools.html#spatial-bookmarks).

--- a/documentation/how-to/gnss.en.md
+++ b/documentation/how-to/gnss.en.md
@@ -1,8 +1,8 @@
 ---
-title: GNSS
+title: Positioning (GNSS)
 ---
 
-# GNSS
+# Positioning (GNSS)
 
 QField can make use of the internal GNSS (Global Navigation Satellite
 System, like GPS, GLONASS, Galileo or Beidou). QField can also connect

--- a/documentation/how-to/hiding-legend-nodes.en.md
+++ b/documentation/how-to/hiding-legend-nodes.en.md
@@ -1,12 +1,12 @@
 ---
-title: Hiding Legend Nodes
+title: Hiding legend nodes
 ---
 
-# Hiding Legend Nodes
+# Hiding legend nodes
 
 It is possible to configure your QGIS projet to allow hiding legend nodes
 
-## Configure Hidden Nodes
+## Configure hidden nodes
 :material-desktop-mac:{ .device-icon } Desktop preparation
 
 First, you should verify if the plugin *Invisible layers and

--- a/documentation/how-to/live-default-value.en.md
+++ b/documentation/how-to/live-default-value.en.md
@@ -1,8 +1,8 @@
 ---
-title: Live Default Value
+title: Live default value
 ---
 
-# Live Default Value
+# Live default value
 
 QField is supporting the "live" updating of default attribute value
 when editing features.

--- a/documentation/how-to/map-themes.en.md
+++ b/documentation/how-to/map-themes.en.md
@@ -1,5 +1,5 @@
 ---
-title: Map Themes
+title: Map themes
 ---
 
 # Map themes
@@ -7,7 +7,7 @@ The beautiful thing about GIS is that maps are dynamic. Layers can
 individually be shown and hidden and information can be presented more
 or less prominently based on the task at hand.
 
-This is what *Map Themes* are for.
+This is what *Map themes* are for.
 
 ## Creating a Map Theme
 :material-desktop-mac:{ .device-icon } Desktop preparation
@@ -24,7 +24,7 @@ Creating a Map Theme in QGIS is a very simple task.
 :material-tablet-android:{ .device-icon } Fieldwork
 
 If you defined map themes for your project in QGIS, you can switch
-between them from the Dashboard. Use the *Map Themes* combobox to chose
+between them from the Dashboard. Use the *Map themes* combobox to chose
 the active theme.
 
 !![Change Map Theme](../assets/images/theme.webp)

--- a/documentation/how-to/movable-project.en.md
+++ b/documentation/how-to/movable-project.en.md
@@ -1,15 +1,15 @@
 ---
-title: Movable project
+title: Portable project
 ---
 
-# Movable project
+# Portable project
 
 To manually synchronise your QGIS project, you will need a portable
 version of your .qgs file. Portable means that all paths are relative
 and datasets are reachable from the device.
 
 
-## Configure a Movable Project
+## Configure a portable project
 :material-desktop-mac:{ .device-icon } Desktop preparation
 
 Check that

--- a/documentation/how-to/outside-layers.en.md
+++ b/documentation/how-to/outside-layers.en.md
@@ -1,8 +1,9 @@
 ---
-title: Outside Layer
+title: Shared local datasets
 ---
 
-# Outside Layer
+# Shared local datasets
+
 In a QField project it is possible to use a layer outside the project
 folder, like a basemap.
 

--- a/documentation/how-to/projects.en.md
+++ b/documentation/how-to/projects.en.md
@@ -1,8 +1,8 @@
 ---
-title: Project Selection
+title: Project selection
 ---
 
-# Project Selection
+# Project selection
 
 QField has a file selector that allows to open a project from the device locally. To open files from the cloud see [QFieldCloud ](../../get-started/tutorials/get-started-qfc/).
 


### PR DESCRIPTION
Make sure all title are in Sentence case, not in Title Case, as most of the docs are already in Sentence case. E.g. `Attribute Form` is `Attribute form` now.

Also rename some strange names like:

`Outside Layer` -> `Shared local datasets`
`Movable projects` -> `Portable projects`
`GNSS` -> `Positioning (GNSS)`