### PR TITLE
Makes the package installable by working around transifex. Currently …

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,7 @@ where all the real documentation text is located.
 #### Testing your changes
 
 ```sh
+pipenv run pip install transifex-client
 pipenv install -r requirements.txt
 pipenv run mkdocs serve
 ```

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,4 +4,3 @@ mkdocs-static-i18n==0.45
 fancyboxmd==1.1.0
 PyGithub==1.55
 python-dotenv==0.19.2
-transifex-client==0.14.4


### PR DESCRIPTION
…transifex does not install properly from a pinned version declared in requirements.txt as pipenv will fail to chain load to the installer it really wants. Removing it from requirements and installing from a separate command works. 

This is but a medium-term fix: ideally the package should be installed from a real dependencies solver, i.e poetry. This would allow to specify the Python version for better reproducibility.