### PR TITLE
Transifex translation management

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -3,10 +3,12 @@ name: gh-pages
 on:
   push:
     branches:
+      - transifex_stuff
+      # FIXME: restore
       - master
-  schedule:
-    - cron: '30 1 * * *'
-  workflow_dispatch:
+  # schedule:
+  #   - cron: '30 1 * * *'
+  # workflow_dispatch:
 
 permissions:
   contents: write
@@ -40,19 +42,21 @@ jobs:
 
       - name: Pull translations
         run: |
-          ./tx add --project qfield-documentation --file-filter 'documentation/<project_slug>.<resource_slug>/<lang>.<ext>' remote https://www.transifex.com/opengisch/qfield-documentation/dashboard/
-          ./tx pull --minimum-perc 10
+          python ./utils/transifex_utils.py
+          ./tx pull -l it,de,fr,es
+          ./tx status
+          cat ./documentation/get-started/tutorials/advanced-setup-qfc.it.md
         env:
           TX_TOKEN: ${{ secrets.TX_TOKEN }}
 
-      - name: Build documentation
-        run: mkdocs build
-        env:
-          DEFAULT_LANGUAGE_ONLY: false
+      # - name: Build documentation
+      #   run: mkdocs build
+      #   env:
+      #     DEFAULT_LANGUAGE_ONLY: false
 
-      - name: Deploy to GitHub Pages
-        uses: JamesIves/github-pages-deploy-action@v4.2.2
-        with:
-            branch: gh-pages
-            clean: true
-            folder: site
+      # - name: Deploy to GitHub Pages
+      #   uses: JamesIves/github-pages-deploy-action@v4.2.2
+      #   with:
+      #       branch: gh-pages
+      #       clean: true
+      #       folder: site

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -3,12 +3,10 @@ name: gh-pages
 on:
   push:
     branches:
-      - transifex_stuff
-      # FIXME: restore
       - master
-  # schedule:
-  #   - cron: '30 1 * * *'
-  # workflow_dispatch:
+  schedule:
+    - cron: '30 1 * * *'
+  workflow_dispatch:
 
 permissions:
   contents: write
@@ -64,9 +62,9 @@ jobs:
         env:
           DEFAULT_LANGUAGE_ONLY: false
 
-      # - name: Deploy to GitHub Pages
-      #   uses: JamesIves/github-pages-deploy-action@v4.2.2
-      #   with:
-      #       branch: gh-pages
-      #       clean: true
-      #       folder: site
+      - name: Deploy to GitHub Pages
+        uses: JamesIves/github-pages-deploy-action@v4.2.2
+        with:
+            branch: gh-pages
+            clean: true
+            folder: site

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -48,7 +48,7 @@ jobs:
 
       - name: Push source files to Transifex
         run: |
-          ./tx push --source --all
+          ./tx push
         env:
           TX_TOKEN: ${{ secrets.TX_TOKEN }}
 

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -43,16 +43,15 @@ jobs:
       - name: Pull translations
         run: |
           python ./utils/transifex_utils.py
-          ./tx pull -l it,de,fr,es
+          ./tx pull --all --minimum-perc 10
           ./tx status
-          cat ./documentation/get-started/tutorials/advanced-setup-qfc.it.md
         env:
           TX_TOKEN: ${{ secrets.TX_TOKEN }}
 
-      # - name: Build documentation
-      #   run: mkdocs build
-      #   env:
-      #     DEFAULT_LANGUAGE_ONLY: false
+      - name: Build documentation
+        run: mkdocs build
+        env:
+          DEFAULT_LANGUAGE_ONLY: false
 
       # - name: Deploy to GitHub Pages
       #   uses: JamesIves/github-pages-deploy-action@v4.2.2

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -40,10 +40,21 @@ jobs:
           curl -OL https://github.com/transifex/cli/releases/download/v1.3.1/tx-linux-amd64.tar.gz
           tar -xvzf tx-linux-amd64.tar.gz
 
-      - name: Pull translations
+      - name: Configure Transifex
         run: |
           python ./utils/transifex_utils.py
-          ./tx pull --all --minimum-perc 10
+        env:
+          TX_TOKEN: ${{ secrets.TX_TOKEN }}
+
+      - name: Push source files to Transifex
+        run: |
+          ./tx push --source --all
+        env:
+          TX_TOKEN: ${{ secrets.TX_TOKEN }}
+
+      - name: Pull translations from Transifex
+        run: |
+          ./tx pull --translations --all --minimum-perc 10
           ./tx status
         env:
           TX_TOKEN: ${{ secrets.TX_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -93,8 +93,19 @@ and cannot do any damage, feel free to experiment.
 If you want more information about forking you can find it
 [here](https://help.github.com/articles/fork-a-repo/).
 
-You most likely want to make changes to the files in the folder `en`. That's
-where all the real documentation text is located.
+Only English source files are to be edited manually in the repository.
+Files ending in `.en.md` are uploaded to Transifex for translation.
+
+It is necessary to create a unique `tx_slug` in the metadata of the newly created markdown files. E.g:
+
+  ```markdown
+    ---
+    title: Advanced Setup
+    tx_slug: tutorial_advanced_setup_qfc
+    ---
+  ```
+
+The `tx_slug` identifies the resource on Transifex. It should *not* be changed in existing files, otherwise unnecessary duplication is created on Transifex.
 
 #### Testing your changes (on your local machine)
 

--- a/documentation/get-started/concepts.en.md
+++ b/documentation/get-started/concepts.en.md
@@ -1,5 +1,6 @@
 ---
 title: Concepts
+tx_slug: documentation_get-started_concepts
 ---
 
 # Concepts

--- a/documentation/get-started/contribute.en.md
+++ b/documentation/get-started/contribute.en.md
@@ -1,5 +1,6 @@
 ---
 title: Contribute
+tx_slug: documentation_get-started_contribute
 ---
 
 # Contribute

--- a/documentation/get-started/faq.en.md
+++ b/documentation/get-started/faq.en.md
@@ -1,5 +1,6 @@
 ---
 title: FAQ
+tx_slug: documentation_get-started_faq
 ---
 
 # Frequently Asked Questions

--- a/documentation/get-started/index.en.md
+++ b/documentation/get-started/index.en.md
@@ -1,5 +1,6 @@
 ---
 title: Get started
+tx_slug: documentation_get-started_index
 ---
 
 # Get started with QField and QFieldCloud

--- a/documentation/get-started/license.en.md
+++ b/documentation/get-started/license.en.md
@@ -1,5 +1,6 @@
 ---
 title: License
+tx_slug: documentation_get-started_license
 ---
 
 # License

--- a/documentation/get-started/sample-projects.en.md
+++ b/documentation/get-started/sample-projects.en.md
@@ -1,5 +1,6 @@
 ---
 title: Sample projects
+tx_slug: documentation_get-started_sample-projects
 ---
 
 # Sample projects

--- a/documentation/get-started/sponsor.en.md
+++ b/documentation/get-started/sponsor.en.md
@@ -1,5 +1,6 @@
 ---
 title: Sponsor
+tx_slug: documentation_get-started_sponsor
 ---
 
 # Sponsor QField

--- a/documentation/get-started/storage.en.md
+++ b/documentation/get-started/storage.en.md
@@ -1,5 +1,6 @@
 ---
 title: Storage Access
+tx_slug: documentation_get-started_storage
 ---
 
 # QField Storage Access

--- a/documentation/get-started/support.en.md
+++ b/documentation/get-started/support.en.md
@@ -1,5 +1,6 @@
 ---
 title: Support
+tx_slug: documentation_get-started_support
 ---
 
 # Support

--- a/documentation/get-started/third-part-tutorials.en.md
+++ b/documentation/get-started/third-part-tutorials.en.md
@@ -1,5 +1,6 @@
 ---
 title: Third-party tutorials
+tx_slug: documentation_get-started_third-part-tutorials
 ---
 
 # Third-party tutorials

--- a/documentation/get-started/tutorials/advanced-setup-qfc.en.md
+++ b/documentation/get-started/tutorials/advanced-setup-qfc.en.md
@@ -1,5 +1,6 @@
 ---
 title: Advanced Setup
+tx_slug: documentation_get-started_tutorials_advanced-setup-qfc
 ---
 
 # Advanced setup guide

--- a/documentation/get-started/tutorials/get-started-qfc.en.md
+++ b/documentation/get-started/tutorials/get-started-qfc.en.md
@@ -1,5 +1,6 @@
 ---
 title: Get Started
+tx_slug: documentation_get-started_tutorials_get-started-qfc
 ---
 
 # Getting started guide

--- a/documentation/get-started/tutorials/get-started-qfs.en.md
+++ b/documentation/get-started/tutorials/get-started-qfs.en.md
@@ -1,5 +1,6 @@
 ---
 title: Get Started
+tx_slug: documentation_get-started_tutorials_get-started-qfs
 ---
 
 # QFieldSync plugin

--- a/documentation/how-to/attributes-form.en.md
+++ b/documentation/how-to/attributes-form.en.md
@@ -1,5 +1,6 @@
 ---
 title: Attribute form
+tx_slug: documentation_how-to_attributes-form
 ---
 
 # Attribute form

--- a/documentation/how-to/authentication.en.md
+++ b/documentation/how-to/authentication.en.md
@@ -1,5 +1,6 @@
 ---
 title: Authentication
+tx_slug: documentation_how-to_authentication
 ---
 
 # Authentication

--- a/documentation/how-to/bookmarks.en.md
+++ b/documentation/how-to/bookmarks.en.md
@@ -1,5 +1,6 @@
 ---
 title: Bookmarks
+tx_slug: documentation_how-to_bookmarks
 ---
 
 # Bookmarks

--- a/documentation/how-to/digitize.en.md
+++ b/documentation/how-to/digitize.en.md
@@ -1,5 +1,6 @@
 ---
 title: Digitize
+tx_slug: documentation_how-to_digitize
 ---
 
 # Digitize

--- a/documentation/how-to/gnss.en.md
+++ b/documentation/how-to/gnss.en.md
@@ -1,5 +1,6 @@
 ---
 title: Positioning (GNSS)
+tx_slug: documentation_how-to_gnss
 ---
 
 # Positioning (GNSS)

--- a/documentation/how-to/hiding-legend-nodes.en.md
+++ b/documentation/how-to/hiding-legend-nodes.en.md
@@ -1,5 +1,6 @@
 ---
 title: Hiding legend nodes
+tx_slug: documentation_how-to_hiding-legend-nodes
 ---
 
 # Hiding legend nodes

--- a/documentation/how-to/index.en.md
+++ b/documentation/how-to/index.en.md
@@ -1,5 +1,6 @@
 ---
 title: How-to guides
+tx_slug: documentation_how-to_index
 ---
 
 # How-to guides

--- a/documentation/how-to/itinerary.en.md
+++ b/documentation/how-to/itinerary.en.md
@@ -1,5 +1,6 @@
 ---
 title: Advanced itinerary
+tx_slug: documentation_how-to_itinerary
 ---
 
 # Advanced Itinerary

--- a/documentation/how-to/live-default-value.en.md
+++ b/documentation/how-to/live-default-value.en.md
@@ -1,5 +1,6 @@
 ---
 title: Live default value
+tx_slug: documentation_how-to_live-default-value
 ---
 
 # Live default value

--- a/documentation/how-to/map-interaction.en.md
+++ b/documentation/how-to/map-interaction.en.md
@@ -1,5 +1,6 @@
 ---
 title: Interact with the map
+tx_slug: documentation_how-to_map-interaction
 ---
 
 # Interact with the map

--- a/documentation/how-to/map-styling.en.md
+++ b/documentation/how-to/map-styling.en.md
@@ -1,5 +1,6 @@
 ---
 title: Map styling
+tx_slug: documentation_how-to_map-styling
 ---
 
 # Map styling

--- a/documentation/how-to/map-themes.en.md
+++ b/documentation/how-to/map-themes.en.md
@@ -1,5 +1,6 @@
 ---
 title: Map themes
+tx_slug: documentation_how-to_map-themes
 ---
 
 # Map themes

--- a/documentation/how-to/movable-project.en.md
+++ b/documentation/how-to/movable-project.en.md
@@ -1,5 +1,6 @@
 ---
 title: Portable project
+tx_slug: documentation_how-to_movable-project
 ---
 
 # Portable project

--- a/documentation/how-to/navigation.en.md
+++ b/documentation/how-to/navigation.en.md
@@ -1,5 +1,6 @@
 ---
 title: Navigation
+tx_slug: documentation_how-to_navigation
 ---
 
 # Navigation

--- a/documentation/how-to/outside-layers.en.md
+++ b/documentation/how-to/outside-layers.en.md
@@ -1,5 +1,6 @@
 ---
 title: Shared local datasets
+tx_slug: documentation_how-to_outside-layers
 ---
 
 # Shared local datasets

--- a/documentation/how-to/pg-service.en.md
+++ b/documentation/how-to/pg-service.en.md
@@ -1,5 +1,6 @@
 ---
 title: PostgreSQL service
+tx_slug: documentation_how-to_pg-service
 ---
 
 # PostgreSQL service

--- a/documentation/how-to/pictures.en.md
+++ b/documentation/how-to/pictures.en.md
@@ -1,5 +1,6 @@
 ---
 title: Pictures
+tx_slug: documentation_how-to_pictures
 ---
 
 # Use pictures

--- a/documentation/how-to/print-to-pdf.en.md
+++ b/documentation/how-to/print-to-pdf.en.md
@@ -1,5 +1,6 @@
 ---
 title: Print to PDF
+tx_slug: documentation_how-to_print-to-pdf
 ---
 
 # Print to PDF

--- a/documentation/how-to/projects.en.md
+++ b/documentation/how-to/projects.en.md
@@ -1,5 +1,6 @@
 ---
 title: Project selection
+tx_slug: documentation_how-to_projects
 ---
 
 # Project selection

--- a/documentation/how-to/search.en.md
+++ b/documentation/how-to/search.en.md
@@ -1,5 +1,6 @@
 ---
 title: Search
+tx_slug: documentation_how-to_search
 ---
 
 # Search

--- a/documentation/how-to/standalone-datasets.en.md
+++ b/documentation/how-to/standalone-datasets.en.md
@@ -1,5 +1,6 @@
 ---
 title: Standalone datasets
+tx_slug: documentation_how-to_standalone-datasets
 ---
 
 # Standalone datasets

--- a/documentation/how-to/temporal-filtering.en.md
+++ b/documentation/how-to/temporal-filtering.en.md
@@ -1,5 +1,6 @@
 ---
 title: Temporal filtering
+tx_slug: documentation_how-to_temporal-filtering
 ---
 
 # Temporal filtering

--- a/documentation/how-to/tracking.en.md
+++ b/documentation/how-to/tracking.en.md
@@ -1,5 +1,6 @@
 ---
 title: Tracking
+tx_slug: documentation_how-to_tracking
 ---
 
 # Tracking

--- a/documentation/how-to/variables.en.md
+++ b/documentation/how-to/variables.en.md
@@ -1,5 +1,6 @@
 ---
 title: Global variables
+tx_slug: documentation_how-to_variables
 ---
 
 # Global variables

--- a/documentation/reference/data-format.en.md
+++ b/documentation/reference/data-format.en.md
@@ -1,5 +1,6 @@
 ---
 title: Supported Data Formats
+tx_slug: documentation_reference_data-format
 ---
 
 # Supported Data Formats

--- a/documentation/reference/index.en.md
+++ b/documentation/reference/index.en.md
@@ -1,5 +1,6 @@
 ---
 title: Technical reference
+tx_slug: documentation_reference_index
 ---
 
 # Technical reference

--- a/documentation/reference/qfieldcloud/api.en.md
+++ b/documentation/reference/qfieldcloud/api.en.md
@@ -1,5 +1,6 @@
 ---
 title: REST API
+tx_slug: documentation_reference_qfieldcloud_api
 ---
 #
 You can also visit the API documentation at https://app.qfield.cloud/docs/ .

--- a/documentation/reference/qfieldcloud/concepts.en.md
+++ b/documentation/reference/qfieldcloud/concepts.en.md
@@ -1,5 +1,6 @@
 ---
 title: Basic concepts
+tx_slug: documentation_reference_qfieldcloud_concepts
 ---
 
 ## Users

--- a/documentation/reference/qfieldcloud/jobs.en.md
+++ b/documentation/reference/qfieldcloud/jobs.en.md
@@ -1,5 +1,6 @@
 ---
 title: Jobs
+tx_slug: documentation_reference_qfieldcloud_jobs
 ---
 
 Jobs on QFieldCloud perform heavy operation with project files and layers within QGIS. Jobs are created in response to certain user actions.

--- a/documentation/reference/qfieldcloud/permissions.en.md
+++ b/documentation/reference/qfieldcloud/permissions.en.md
@@ -1,5 +1,6 @@
 ---
 title: Permissions
+tx_slug: documentation_reference_qfieldcloud_permissions
 ---
 
 # Permissions

--- a/documentation/reference/qfieldcloud/projects.en.md
+++ b/documentation/reference/qfieldcloud/projects.en.md
@@ -1,5 +1,6 @@
 ---
 title: Projects
+tx_slug: documentation_reference_qfieldcloud_projects
 ---
 
 Projects are the main data container within QFieldCloud. Each user can create one or more QFieldCloud projects. Each project contains a single `.qgs`/`.qgz` QGIS project file, the geospatial files - GeoPackages, Shapefiles, TIFs, and additional data such as photos, PDFs etc. All project data files must be within a single QFieldCloud project.

--- a/documentation/reference/qfieldcloud/sdk.en.md
+++ b/documentation/reference/qfieldcloud/sdk.en.md
@@ -1,5 +1,6 @@
 ---
 title: The official QFieldCloud SDK and CLI
+tx_slug: documentation_reference_qfieldcloud_sdk
 ---
 
 `qfieldcloud-sdk` is the official client to connect to [QFieldCloud API](api.md) either as a python module, or directly from the command line.

--- a/documentation/reference/qfieldcloud/secrets.en.md
+++ b/documentation/reference/qfieldcloud/secrets.en.md
@@ -1,5 +1,6 @@
 ---
 title: Secrets
+tx_slug: documentation_reference_qfieldcloud_secrets
 ---
 
 # Secrets

--- a/documentation/reference/qfieldcloud/specs.en.md
+++ b/documentation/reference/qfieldcloud/specs.en.md
@@ -1,5 +1,6 @@
 ---
 title: Technical specs
+tx_slug: documentation_reference_qfieldcloud_specs
 ---
 
 ## Firewall configuration

--- a/documentation/reference/qfieldcloud/system.en.md
+++ b/documentation/reference/qfieldcloud/system.en.md
@@ -1,5 +1,6 @@
 ---
 title: System Documentation
+tx_slug: documentation_reference_qfieldcloud_system
 ---
 
 # QFieldCloud System Documentation

--- a/documentation/success-stories/ecological-surveying.en.md
+++ b/documentation/success-stories/ecological-surveying.en.md
@@ -1,5 +1,6 @@
 ---
 title: Improving Efficiencies in Ecological Surveying
+tx_slug: documentation_success-stories_ecological-surveying
 ---
 
 # Improving Efficiencies in Ecological Surveying using QField

--- a/documentation/success-stories/geologic-mapping.en.md
+++ b/documentation/success-stories/geologic-mapping.en.md
@@ -1,5 +1,6 @@
 ---
 title: Geologic Mapping
+tx_slug: documentation_success-stories_geologic-mapping
 ---
 
 # Geologic Mapping with QField

--- a/documentation/success-stories/heritage-impact-assessment.en.md
+++ b/documentation/success-stories/heritage-impact-assessment.en.md
@@ -1,5 +1,6 @@
 ---
 title: Heritage Impact Assessment
+tx_slug: documentation_success-stories_heritage-impact-assessment
 ---
 
 # Heritage Impact Assessment using QField

--- a/documentation/success-stories/index.en.md
+++ b/documentation/success-stories/index.en.md
@@ -1,5 +1,6 @@
 ---
 title: Success Stories
+tx_slug: documentation_success-stories_index
 ---
 
 # Success Stories

--- a/documentation/success-stories/lulc-mapping-fiji.en.md
+++ b/documentation/success-stories/lulc-mapping-fiji.en.md
@@ -1,5 +1,6 @@
 ---
 title: Ground Truth Data Collection
+tx_slug: documentation_success-stories_lulc-mapping-fiji
 ---
 
 # Ground Truth Data Collection Using QField for LULC Mapping in Fiji

--- a/documentation/success-stories/mapping-breeding-birds-in-the-Wadden-Sea.en.md
+++ b/documentation/success-stories/mapping-breeding-birds-in-the-Wadden-Sea.en.md
@@ -1,5 +1,6 @@
 ---
 title: Mapping breeding birds
+tx_slug: documentation_success-stories_mapping-breeding-birds-in-the-Wadden-Sea
 ---
 
 # Use of QField for mapping breeding birds in the Wadden Sea

--- a/documentation/success-stories/mosquito-malario-ground-truth-data-collection.en.md
+++ b/documentation/success-stories/mosquito-malario-ground-truth-data-collection.en.md
@@ -1,5 +1,6 @@
 ---
 title: Data collection of malaria transmitting mosquitoes
+tx_slug: documentation_success-stories_mosquito-malario-ground-truth-data-collection
 ---
 
 # Use of Qfield in the context of ground-truth data collection work of malaria transmitting mosquitoes

--- a/documentation/success-stories/river-state-survey.en.md
+++ b/documentation/success-stories/river-state-survey.en.md
@@ -1,5 +1,6 @@
 ---
 title: River State Survey
+tx_slug: documentation_success-stories_river-state-survey
 ---
 
 # River State Survey Using QField

--- a/documentation/success-stories/rwanda-rural-water.en.md
+++ b/documentation/success-stories/rwanda-rural-water.en.md
@@ -1,5 +1,6 @@
 ---
 title: Data collection of rural water supply systems
+tx_slug: documentation_success-stories_rwanda-rural-water
 ---
 
 # Data collection by QGIS/QField for O&M work of rural water supply systems in Rwanda

--- a/documentation/success-stories/vanilla-survey.en.md
+++ b/documentation/success-stories/vanilla-survey.en.md
@@ -1,5 +1,6 @@
 ---
 title: Vanilla Surveys
+tx_slug: documentation_success-stories_vanilla-survey
 ---
 
 # Vanilla Surveys using QField

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ mkdocs-static-i18n==0.47
 fancyboxmd==1.1.0
 PyGithub==1.55
 python-dotenv==0.19.2
+python-frontmatter==1.0.0

--- a/utils/transifex_utils.py
+++ b/utils/transifex_utils.py
@@ -1,5 +1,36 @@
+import os
+import glob
 import frontmatter
 
+TX_ORGANIZATION = "opengisch"
+TX_PROJECT = "qfield_documentation"
+TX_SOURCE_LANG = "en"
+TX_TYPE = "GITHUBMARKDOWN"
 
 def create_transifex_config():
-    pass
+    """ Parse all source documentation files and add the ones with tx_slug metadata
+    defined to transifex config file.
+    """
+    current_dir = os.path.dirname(os.path.abspath(__file__))
+    config_file = os.path.join(current_dir, "..", ".tx", "config")
+    root = os.path.join(current_dir, "..")
+
+    with open(config_file, "w") as f:
+        f.write("[main]\n")
+        f.write("host = https://www.transifex.com\n\n")
+
+        for file in glob.iglob(current_dir + '/../documentation/**/*.en.md', recursive=True):
+
+            # Get relative path of file
+            relative_path = os.path.relpath(file, start = root)
+
+            tx_slug = frontmatter.load(file).get('tx_slug', None)
+
+            if tx_slug:
+                f.write(f"[o:{TX_ORGANIZATION}:p:{TX_PROJECT}:r:{tx_slug}]\n")
+                f.write(f"file_filter = {''.join(relative_path.split('.')[:-2])}.<lang>.md\n")
+                f.write(f"source_file = {relative_path}\n")
+                f.write(f"source_lang = {TX_SOURCE_LANG}\n")
+                f.write(f"type = {TX_TYPE}\n\n")
+
+create_transifex_config()

--- a/utils/transifex_utils.py
+++ b/utils/transifex_utils.py
@@ -3,7 +3,7 @@ import glob
 import frontmatter
 
 TX_ORGANIZATION = "opengisch"
-TX_PROJECT = "qfield_documentation"
+TX_PROJECT = "qfield-documentation"
 TX_SOURCE_LANG = "en"
 TX_TYPE = "GITHUBMARKDOWN"
 

--- a/utils/transifex_utils.py
+++ b/utils/transifex_utils.py
@@ -29,7 +29,6 @@ def create_transifex_config():
 
             tx_slug = frontmatter.load(file).get('tx_slug', None)
 
-
             if tx_slug:
                 print(f"Found file with tx_slug defined: {relative_path}, {tx_slug}")
                 f.write(f"[o:{TX_ORGANIZATION}:p:{TX_PROJECT}:r:{tx_slug}]\n")

--- a/utils/transifex_utils.py
+++ b/utils/transifex_utils.py
@@ -16,6 +16,7 @@ def create_transifex_config():
     current_dir = os.path.dirname(os.path.abspath(__file__))
     config_file = os.path.join(current_dir, "..", ".tx", "config")
     root = os.path.join(current_dir, "..")
+    count = 0
 
     with open(config_file, "w") as f:
         f.write("[main]\n")
@@ -36,6 +37,8 @@ def create_transifex_config():
                 f.write(f"source_file = {relative_path}\n")
                 f.write(f"source_lang = {TX_SOURCE_LANG}\n")
                 f.write(f"type = {TX_TYPE}\n\n")
+                count += 1
 
-    print("Transifex configuration created")
+    print(f"Transifex configuration created. {count} resources added.")
+
 create_transifex_config()

--- a/utils/transifex_utils.py
+++ b/utils/transifex_utils.py
@@ -11,6 +11,8 @@ def create_transifex_config():
     """ Parse all source documentation files and add the ones with tx_slug metadata
     defined to transifex config file.
     """
+    print("Start creating transifex configuration")
+
     current_dir = os.path.dirname(os.path.abspath(__file__))
     config_file = os.path.join(current_dir, "..", ".tx", "config")
     root = os.path.join(current_dir, "..")
@@ -26,11 +28,14 @@ def create_transifex_config():
 
             tx_slug = frontmatter.load(file).get('tx_slug', None)
 
+
             if tx_slug:
+                print(f"Found file with tx_slug defined: {relative_path}, {tx_slug}")
                 f.write(f"[o:{TX_ORGANIZATION}:p:{TX_PROJECT}:r:{tx_slug}]\n")
                 f.write(f"file_filter = {''.join(relative_path.split('.')[:-2])}.<lang>.md\n")
                 f.write(f"source_file = {relative_path}\n")
                 f.write(f"source_lang = {TX_SOURCE_LANG}\n")
                 f.write(f"type = {TX_TYPE}\n\n")
 
+    print("Transifex configuration created")
 create_transifex_config()

--- a/utils/transifex_utils.py
+++ b/utils/transifex_utils.py
@@ -1,0 +1,5 @@
+import frontmatter
+
+
+def create_transifex_config():
+    pass


### PR DESCRIPTION
The idea of this PR is to fix translation management problems with Transifex.

The problems are due to:
- Transifex CLI change that no longer allows for satisfactory automated "add bulk" [(see here)](https://github.com/transifex/cli#adding-resources-in-bulk) to populate the configuration file
- the fact that using an automated system to populate the Transifex configuration, if a file is moved or renamed, it changes the resource name and duplicates of the resource are created on Transifex.

Proposal of this PR:
- a unique "tx_slug" metadata is manually added to each documentation page using markdown frontmatter syntax (already used in mkdocs)
- a python script parses all directories, and when it finds a markdown file, it reads the "tx_slug" and adds the file to the Transifex configuration (.tx/config) using the "tx_slug" as the resource name.

Example of the syntax:
```markdown
---
title: Advanced Setup
tx_slug: tutorial_advanced_setup_qfc
---

```

We will still need to do a manual cleanup of the resources in Transifex to clean up any duplicates and rename the resources when needed.

TODO:
- [x] Prepare script to create Transifex configuration
- [x] Manually add tx_slug to all documents, using actual resource slugs from Transifex
- [x] Cleanup Transifex resources if needed
- [x] Test pull translations and multilanguage documentation build
- [x] Add push translations and Finalize github action
- [x] Document in readme