### PR TITLE
Fix tiny vimeo video frame on mobile devices

### DIFF
--- a/theme_overrides/assets/stylesheets/main.3ca7bbfe.min.css
+++ b/theme_overrides/assets/stylesheets/main.3ca7bbfe.min.css
@@ -467,6 +467,9 @@ kbd {
 .md-typeset iframe {
     max-width:100%
 }
+.md-typeset .video-container iframe {
+    min-height: 185px !important;
+}
 .md-typeset table:not([class]) {
     display:inline-block;
     max-width:100%;


### PR DESCRIPTION
This PR aims at fixing the teeny-tiny vimeo video featured in the getting started documentation page, i.e. this:
![image](https://user-images.githubusercontent.com/1728657/195967730-3bfac486-98f0-482c-a571-d06cf88d6fdc.png)

I'm mentioning aimed as while the CSS here is correct, I am not sure editing `theme_overrides/assets/stylesheets/main.3ca7bbfe.min.css` does anything these days. 

With the CSS tweak applied, the page looks a lot nicer:
![image](https://user-images.githubusercontent.com/1728657/195967781-793de694-ba58-4340-bb36-5937b359501e.png)
