### PR TITLE
Nav headers translated

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -196,3 +196,25 @@ plugins:
         # ru: Russian
         # ru_UA: Russian (Ukraine)
         # vi: Vietnamese
+      nav_translations:
+        de:
+          Get started: Erste Schritte
+          How-to guides: Tutorial
+          Technical reference: Technische Referenz
+          Success stories: Erfolgsgeschichten
+        fr:
+          Get started: Mise en route
+          How-to guides: Tutoriels
+          Technical reference: Référence technique
+          Success stories: Témoignages de projets
+        it:
+          Get started: Guida introduttiva
+          How-to guides: Tutorial
+          Technical reference: Riferimento tecnico
+          Success stories: Storie di successo
+        es:
+          Get started: Primeros pasos
+          How-to guides: Tutorial
+          Technical reference: Referencia técnica
+          Success stories: Historias de éxito
+

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -217,4 +217,3 @@ plugins:
           How-to guides: Tutorial
           Technical reference: Referencia técnica
           Success stories: Historias de éxito
-


### PR DESCRIPTION
Addressing #274 (_add translated headers_).

Better have these proof-read by more competent speakers.

To be sure, I am adding these translation strings manually because AFAIK we don't hav a procedure for translation strings that don't reference any particular source file (as `mkdocs.yml` doesn't qualify as source file) as they are not pushed to transifex.com.