### PR TITLE
Less ambitious pull of translation strings

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -52,7 +52,7 @@ jobs:
 
       - name: Pull translations from Transifex
         run: |
-          ./tx pull --translations --all --minimum-perc 10
+          ./tx pull -t -l en,de,fr,it,es
           ./tx status
         env:
           TX_TOKEN: ${{ secrets.TX_TOKEN }}

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -164,14 +164,14 @@ plugins:
       # with >30% translations are built. See https://www.transifex.com/opengisch/qfield-documentation/dashboard/
       languages:
         en: English
-        de: German
-        fr: French
-        it: Italian
+        de: Deutsch
+        fr: Français
+        it: Italiano
         # rm: Romansh
         # ja: Japanese
         # gl: Galician
         # pt: Portuguese
-        es: Spanish
+        es: Español
         # hu: Hungarian
         # zh: Chinese
         # fi: Finnish


### PR DESCRIPTION
Addressing #274 (_make sure only languages above a high enough translation..._).

The more sustainable fix would be to fetch the percentage of translated strings from the API. This is coming soon in https://github.com/opengisch/pytransifex/pull/3) so this PR is but a temporary fix.