### PR TITLE
Positioning measure value documentation addition and cleanups

### DIFF
--- a/documentation/how-to/gnss.en.md
+++ b/documentation/how-to/gnss.en.md
@@ -28,6 +28,21 @@ positioning device.
 
 ## Configuration
 
+The following settings are available in QField settings' positioning tab.
+
+### Measure (M) value
+
+When digitizing a geometry onto a vector layer that contains an M dimension,
+QField will add a measurement value to individual vertices whenever the
+coordinate cursor is locked to the current position.
+
+By default, the value will represent the captured position's timestamp (milliseconds
+sincce epoch). You can change this value using the combo box in the settings'
+positioning tab.
+
+The available values to chose from are timestamp, ground speed, bearing, horizontal
+accuracy and vertical accuracy as well as PDOP, HDOP and VDOP.
+
 ### Accuracy requirement
 
 A minimum desired accuracy for measurements can be defined. The quality

--- a/documentation/how-to/gnss.en.md
+++ b/documentation/how-to/gnss.en.md
@@ -27,24 +27,6 @@ positioning device.
 
 
 ## Configuration
-:material-monitor: Desktop preparation
-
-### Vertex log
-
-It is possible to setup a log layer of the collected vertices. This
-allows to keep track of meta data for each vertex like GNSS quality
-attributes and more. To set this up, a point layer can be added to the
-project and attributes configured to store this information.
-
-![](../assets/images/vertex_log1.png){width="600px"}
-
-Then you should assign the role *digitizing logger* on a point layer.
-
-Go to *QFieldSync > Project Properties*
-
-![](../assets/images/vertex_log2.png){width="600px"}
-
-The layer fields must have default value with GNSS variables.
 
 ### Accuracy requirement
 
@@ -88,93 +70,6 @@ The formats currently supported are:
 
 For example:
 For the transformation from ETRS89 (reference ellipsoid GPS) to NAP (Dutch) users can download the file [nlgeo2018.gtx from NSGI](https://www.nsgi.nl/rdnaptrans) and put it in the directory.
-
-### Additional variables
-
-You can get access to positioning information through additional
-expression variables. These will only be available when positioning is
-enabled.
-
-These variables are commonly used as default values for fields to keep
-track of the quality of individual measured points.
-
-  - `@position_source_name` - The name of the device that gave location information as
-    reported by the sensor. To differenciate between internal and
-    external sensor. If the position is manually set, and the
-    position is not snapped to the cursor, the source name is
-    "manual". **In case the cursor is not snapped to the position, all other variables will be null, if you need this, use the
-    `gnss_` variables instead**.
-  - `@position_quality_description` - A human readable and translated string for the quality as
-        reported by the sensor. E.g. "Fixed RTK". It is only available
-        when the crosshair is snapped to the sensor. - IE
-  - `@position_coordinate` - A point with the coordinate in WGS84. Lon, Lat, Altitude as
-        delivered by the sensor. It is only available when the crosshair
-        is snapped to the sensor. - `x(@position_coordinate)` - IE
-  - `@position_horizontal_accuracy` - The horizontal accuracy of the coordinate (in meters) as
-        reported by the sensor. It is only available when the crosshair
-        is snapped to the sensor. - IE
-  - `@position_timestamp` - The timestamp of the position in UTC as reported by the sensor.
-        It is only available when the crosshair is snapped to the
-        sensor. - IE
-  - `@position_direction` - The direction of movement in degrees from true north as reported
-        by the sensor. It is only available when the crosshair is
-        snapped to the sensor. - IE
-  - `@position_ground_speed` - Groundspeed (in m/s) as reported by the sensor. It is only
-        available when the crosshair is snapped to the sensor. - IE
-  - `@position_magnetic_variation` - The angle between the horizontal component of the magnetic field
-        and true north, in degrees as reported by the sensor. Also known
-        as magnetic declination. A positive value indicates a clockwise
-        direction from true north and a negative value indicates a
-        counter-clockwise direction. It is only available when the
-        crosshair is snapped to the sensor. - IE
-  - `@position_vertical_accuracy` - The vertical accuracy of the coordinate (in meters) as reported
-        by the sensor. It is only available when the crosshair is
-        snapped to the sensor. - IE
-  - `@position_3d_accuracy` - The 3 dimensional accuracy of the coordinate (in meters), 3D-RMS
-        as reported by the sensor. It is only available when the
-        crosshair is snapped to the sensor. - IE
-  - `@position_vertical_speed` - The vertical speed (in m/s) as reported by the sensor. It is
-        only available when the crosshair is snapped to the sensor. - IE
-  - `@position_averaged_count` - This variable holds the number of collected positions from
-        which an averaged position was calculated when digitizing in this mode. For non-averaged
-        positions, the value will be set to `0` (zero). - IE
-  - `@position_pdop` - Position dilution of precision as reported by the sensor. It is
-        only available when the crosshair is snapped to the sensor. - E
-  - `@position_hdop` - Horizontal dilution of precision as reported by the sensor. It
-        is only available when the crosshair is snapped to the sensor. - E
-  - `@position_vdop` - Vertical dilution of precision as reported by the sensor. It is
-        only available when the crosshair is snapped to the sensor. - E
-  - `@position_number_of_used_satellites` - Number of satellites as reported by the sensor. It is only
-        available when the crosshair is snapped to the sensor. - IE
-  - `@position_used_satellites` - A list of satellites in use (pri) as reported by the sensor. It
-        is only available when the crosshair is snapped to the sensor. - `array_length(@position_used_satellites)` - E
-  - `@position_fix_status_description` - The GPS Fix Status "NoData", "NoFix", "Fix2D" or "Fix3D"
-        as reported by the sensor. It is only available when the
-        crosshair is snapped to the sensor. - E
-  - `@position_fix_mode` - Fix mode (where "M" = Manual, forced to operate in 2D or 3D or
-        "A" = Automatic, 3D/2D) as reported by the sensor. It is only
-        available when the crosshair is snapped to the sensor. - E
-
-!!! info
-    I: Internal position source E: External (NMEA) position source
-
-All `@position_*` variables have a corresponding `@gnss_*` variable.
-The gnss variables always report the gnss sensor values, even when the
-crosshair is not snapped.
-
-Examples:
-
-:   -   when the crosshair is snapped to the sensor - `@gnss_horizontal_accuracy` > The
-            horizontal accuracy of the coordinate (in meters) as
-            reported by the sensor. - `@position_horizontal_accuracy` > The
-            horizontal accuracy of the coordinate (in meters) as
-            reported by the sensor. - `@position_source_name` --> sensor name.
-    -   when the crosshair is manually moved - `@gnss_horizontal_accuracy` > The
-            horizontal accuracy of the coordinate (in meters) as
-            reported by the sensor. - `@position_horizontal_accuracy` > The value
-            is `NULL`. - `@position_source_name` > The value is
-            `manual`.
-
 
 ## Usage
 :material-tablet: Fieldwork
@@ -256,3 +151,110 @@ When active, holding the add vertex button is not required, a short tap on the b
 !![](../assets/images/positioning_averaged_set.jpg)
 
 When using [`@gnss_*` or `@position_` variables](../gnss/#additional-variables) on averaged positions, the variable will also represent the average over all collected samples.
+
+## Project configuration
+:material-monitor: Desktop preparation
+
+### Positioning variables
+
+You can get access to positioning information through additional
+expression variables accessible in the attribute form. These will
+only be available when positioning is enabled.
+
+These variables are commonly used as default values for fields to keep
+track of the quality of individual measured points.
+
+  - `@position_source_name` - The name of the device that gave location information as
+    reported by the sensor. To differenciate between internal and
+    external sensor. If the position is manually set, and the
+    position is not snapped to the cursor, the source name is
+    "manual". **In case the cursor is not snapped to the position, all other variables will be null, if you need this, use the
+    `gnss_` variables instead**.
+  - `@position_quality_description` - A human readable and translated string for the quality as
+        reported by the sensor. E.g. "Fixed RTK". It is only available
+        when the crosshair is snapped to the sensor. - IE
+  - `@position_coordinate` - A point with the coordinate in WGS84. Lon, Lat, Altitude as
+        delivered by the sensor. It is only available when the crosshair
+        is snapped to the sensor. - `x(@position_coordinate)` - IE
+  - `@position_horizontal_accuracy` - The horizontal accuracy of the coordinate (in meters) as
+        reported by the sensor. It is only available when the crosshair
+        is snapped to the sensor. - IE
+  - `@position_timestamp` - The timestamp of the position in UTC as reported by the sensor.
+        It is only available when the crosshair is snapped to the
+        sensor. - IE
+  - `@position_direction` - The direction of movement in degrees from true north as reported
+        by the sensor. It is only available when the crosshair is
+        snapped to the sensor. - IE
+  - `@position_ground_speed` - Groundspeed (in m/s) as reported by the sensor. It is only
+        available when the crosshair is snapped to the sensor. - IE
+  - `@position_magnetic_variation` - The angle between the horizontal component of the magnetic field
+        and true north, in degrees as reported by the sensor. Also known
+        as magnetic declination. A positive value indicates a clockwise
+        direction from true north and a negative value indicates a
+        counter-clockwise direction. It is only available when the
+        crosshair is snapped to the sensor. - IE
+  - `@position_vertical_accuracy` - The vertical accuracy of the coordinate (in meters) as reported
+        by the sensor. It is only available when the crosshair is
+        snapped to the sensor. - IE
+  - `@position_3d_accuracy` - The 3 dimensional accuracy of the coordinate (in meters), 3D-RMS
+        as reported by the sensor. It is only available when the
+        crosshair is snapped to the sensor. - IE
+  - `@position_vertical_speed` - The vertical speed (in m/s) as reported by the sensor. It is
+        only available when the crosshair is snapped to the sensor. - IE
+  - `@position_averaged_count` - This variable holds the number of collected positions from
+        which an averaged position was calculated when digitizing in this mode. For non-averaged
+        positions, the value will be set to `0` (zero). - IE
+  - `@position_pdop` - Position dilution of precision as reported by the sensor. It is
+        only available when the crosshair is snapped to the sensor. - E
+  - `@position_hdop` - Horizontal dilution of precision as reported by the sensor. It
+        is only available when the crosshair is snapped to the sensor. - E
+  - `@position_vdop` - Vertical dilution of precision as reported by the sensor. It is
+        only available when the crosshair is snapped to the sensor. - E
+  - `@position_number_of_used_satellites` - Number of satellites as reported by the sensor. It is only
+        available when the crosshair is snapped to the sensor. - IE
+  - `@position_used_satellites` - A list of satellites in use (pri) as reported by the sensor. It
+        is only available when the crosshair is snapped to the sensor. - `array_length(@position_used_satellites)` - E
+  - `@position_fix_status_description` - The GPS Fix Status "NoData", "NoFix", "Fix2D" or "Fix3D"
+        as reported by the sensor. It is only available when the
+        crosshair is snapped to the sensor. - E
+  - `@position_fix_mode` - Fix mode (where "M" = Manual, forced to operate in 2D or 3D or
+        "A" = Automatic, 3D/2D) as reported by the sensor. It is only
+        available when the crosshair is snapped to the sensor. - E
+
+!!! info
+    I: Internal position source E: External (NMEA) position source
+
+All `@position_*` variables have a corresponding `@gnss_*` variable.
+The gnss variables always report the gnss sensor values, even when the
+crosshair is not snapped.
+
+Examples:
+
+:   -   when the crosshair is snapped to the sensor - `@gnss_horizontal_accuracy` > The
+            horizontal accuracy of the coordinate (in meters) as
+            reported by the sensor. - `@position_horizontal_accuracy` > The
+            horizontal accuracy of the coordinate (in meters) as
+            reported by the sensor. - `@position_source_name` --> sensor name.
+    -   when the crosshair is manually moved - `@gnss_horizontal_accuracy` > The
+            horizontal accuracy of the coordinate (in meters) as
+            reported by the sensor. - `@position_horizontal_accuracy` > The value
+            is `NULL`. - `@position_source_name` > The value is
+            `manual`.
+
+### Vertex logger
+
+It is possible to setup a log layer of the collected vertices. This
+allows to keep track of meta data for each vertex like GNSS quality
+attributes and more. To set this up, a point layer can be added to the
+project and attributes configured to store this information.
+
+![](../assets/images/vertex_log1.png){width="600px"}
+
+Then you should assign the role *digitizing logger* on a point layer.
+
+Go to *QFieldSync > Project Properties*
+
+![](../assets/images/vertex_log2.png){width="600px"}
+
+To be most effective, the layer attributes should have default value that
+relies on the positioning variables enumerated above.

--- a/documentation/how-to/gnss.en.md
+++ b/documentation/how-to/gnss.en.md
@@ -49,10 +49,11 @@ A minimum desired accuracy for measurements can be defined. The quality
 will be reported in three classes, bad (red), ok (yellow) and excellent
 (green). These colors will show up as a dot on top of the GNSS button.
 
-The thresholds can be defined in the positioning settings.
+The thresholds can be defined in the settings' positioning tab.
 
-If the *Enable accuracy requirement* setting is activated, you will not be able to collect new measurements with the cursor
-snapped to the position with an accuracy value which is bad (red).
+If the *Enable accuracy requirement* setting is activated, you will not
+be able to collect new measurements with the coordinate cursor locked to
+the current position with an accuracy value which is bad (red).
 
 ### Antenna height compensation
 
@@ -66,9 +67,6 @@ calculate orthometric height.
 
 Vertical grid shift files have to be made available to QField by putting
 them into the QField app folder `<drive>:/Android/data/ch.opengis.qfield/files/QField/proj`.
-
-!!! note
-    Since QField 2 the proj files needs to be stored in the app directory `<drive>:/Android/data/ch.opengis.qfield/files/QField/proj` instead of the devices main directory `<drive>:/QField/proj`.
 
 Once the grid shift file is placed there, it is available in QField in
 the *Positioning settings* under *Vertical grid shift in use*.
@@ -84,7 +82,12 @@ The formats currently supported are:
   - Natural Resources Canada's Geoid (.byn)
 
 For example:
-For the transformation from ETRS89 (reference ellipsoid GPS) to NAP (Dutch) users can download the file [nlgeo2018.gtx from NSGI](https://www.nsgi.nl/rdnaptrans) and put it in the directory.
+For the transformation from ETRS89 (reference ellipsoid GPS) to NAP (Dutch) users can download
+the file [nlgeo2018.gtx from NSGI](https://www.nsgi.nl/rdnaptrans) and put it in the directory.
+
+!!! note
+    Since QField 2.0 the proj files needs to be stored in the app directory `<drive>:/Android/data/ch.opengis.qfield/files/QField/proj`
+    instead of the devices main directory `<drive>:/QField/proj`.
 
 ## Usage
 :material-tablet: Fieldwork

--- a/documentation/how-to/gnss.en.md
+++ b/documentation/how-to/gnss.en.md
@@ -37,7 +37,7 @@ QField will add a measurement value to individual vertices whenever the
 coordinate cursor is locked to the current position.
 
 By default, the value will represent the captured position's timestamp (milliseconds
-sincce epoch). You can change this value using the combo box in the settings'
+since epoch). You can change this value using the combo box in the settings'
 positioning tab.
 
 The available values to chose from are timestamp, ground speed, bearing, horizontal
@@ -84,10 +84,6 @@ The formats currently supported are:
 For example:
 For the transformation from ETRS89 (reference ellipsoid GPS) to NAP (Dutch) users can download
 the file [nlgeo2018.gtx from NSGI](https://www.nsgi.nl/rdnaptrans) and put it in the directory.
-
-!!! note
-    Since QField 2.0 the proj files needs to be stored in the app directory `<drive>:/Android/data/ch.opengis.qfield/files/QField/proj`
-    instead of the devices main directory `<drive>:/QField/proj`.
 
 ## Usage
 :material-tablet: Fieldwork
@@ -163,7 +159,7 @@ If an averaged position minimum count requirement is active, a progress bar will
 
 !![](../assets/images/positioning-averaged.webp)
 
-To setting to activate an average position minimum count threshold can be found in QField settings's *positioning* panel.
+The setting to activate an average position minimum count threshold can be found in QField settings's *positioning* panel.
 When active, holding the add vertex button is not required, a short tap on the button will begin the collection of positions and automatically add the averaged position when the minimum count requirement is met.
 
 !![](../assets/images/positioning_averaged_set.jpg)
@@ -179,8 +175,8 @@ You can get access to positioning information through additional
 expression variables accessible in the attribute form. These will
 only be available when positioning is enabled.
 
-These variables are commonly used as default values for fields to keep
-track of the quality of individual measured points.
+These variables are commonly used as part of[default values expressions](https://docs.qgis.org/latest/en/docs/user_manual/working_with_vector/vector_properties.html#default-values)
+for fields to keep track of the quality of individual measured points.
 
   - `@position_source_name` - The name of the device that gave location information as
     reported by the sensor. To differenciate between internal and
@@ -268,11 +264,11 @@ project and attributes configured to store this information.
 
 ![](../assets/images/vertex_log1.png){width="600px"}
 
-Then you should assign the role *digitizing logger* on a point layer.
+Then you should assign the role *digitizing logger* to a point layer.
 
 Go to *QFieldSync > Project Properties*
 
 ![](../assets/images/vertex_log2.png){width="600px"}
 
-To be most effective, the layer attributes should have default value that
+To be most effective, the layer attributes should have default values that
 relies on the positioning variables enumerated above.


### PR DESCRIPTION
While this was initially aimed at adding some documentation to cover a new 2.6 feature (measure (M) value when digitizing), I've taken the opportunity to clean up the sections a bit.

Instead of mixing QField configuration with (QGIS/qfieldsync) project configuration, I've split those into two different sections, with the (slightly) more advanced project configuration relocated towards the bottom. IMHO it makes for a more logical presentation.

@m-kuhn , as discussed, this could then be used as a link in the blog post.