### PR TITLE
add translation pt_pt sitename

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -170,7 +170,10 @@ plugins:
         # rm: Romansh
         # ja: Japanese
         # gl: Galician
-        pt: Portuguese
+        pt: 
+          name: Portuguese
+          site_name: Documentação do Ecossitema QField
+          # site_description: plugin i18N don't accept site_description - Warning: plugins.i18n.languages.pt' unsupported options: site_description
         es: Español
         # hu: Hungarian
         zh: 简体中文
@@ -182,7 +185,7 @@ plugins:
         # bg: Bulgarian
         # cs: Czech
         # fa: Persian
-        # pt_BR: Protuguese (Brazil)
+        # pt_BR: Portuguese (Brazil)
         # et: Estonian
         # pl: Polish
         # he: Hebrew


### PR DESCRIPTION
Hi guys,
I add translation pt_pt for site_name. But I found that the site_description is a unsupported option in the i18n plugin of mkdocs. Please see the error:

Warning: plugins.i18n.languages.pt' unsupported options: site_description

What kind of approach do you want here?

Cheers