### PR TITLE
fix: added translations of the word of 'Home' tab for each language

### DIFF
--- a/.github/workflows/zoho.yml
+++ b/.github/workflows/zoho.yml
@@ -26,7 +26,6 @@ jobs:
         env:
           MKDOCS_INSIDERS_TOKEN: ${{ secrets.MKDOCS_INSIDERS_TOKEN }}
         run: |
-          pip install --upgrade pip
           pip install -r requirements.txt
           pip install -r requirements-insiders.txt
 

--- a/.github/workflows/zoho.yml
+++ b/.github/workflows/zoho.yml
@@ -26,6 +26,7 @@ jobs:
         env:
           MKDOCS_INSIDERS_TOKEN: ${{ secrets.MKDOCS_INSIDERS_TOKEN }}
         run: |
+          pip install --upgrade pip
           pip install -r requirements.txt
           pip install -r requirements-insiders.txt
 

--- a/.github/workflows/zoho.yml
+++ b/.github/workflows/zoho.yml
@@ -4,9 +4,6 @@ on:
   push:
     branches:
       - master
-  pull_request:
-    branches:
-      - master
 
 jobs:
   update:

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -213,7 +213,7 @@ plugins:
           Technical reference: Référence technique
           Success stories: Témoignages de projets
         it:
-          Home: Casa
+          Home: Pagina iniziale
           Get started: Guida introduttiva
           How-to guides: Tutorial
           Technical reference: Riferimento tecnico

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -201,36 +201,43 @@ plugins:
         # vi: Vietnamese
       nav_translations:
         de:
+          Home: Startseite
           Get started: Erste Schritte
           How-to guides: Tutorial
           Technical reference: Technische Referenz
           Success stories: Erfolgsgeschichten
         fr:
+          Home: Accueil
           Get started: Mise en route
           How-to guides: Tutoriels
           Technical reference: Référence technique
           Success stories: Témoignages de projets
         it:
+          Home: Casa
           Get started: Guida introduttiva
           How-to guides: Tutorial
           Technical reference: Riferimento tecnico
           Success stories: Storie di successo
         es:
+          Home: Inicio
           Get started: Primeros pasos
           How-to guides: Tutorial
           Technical reference: Referencia técnica
           Success stories: Historias de éxito
         zh:
+          Home: 首页
           Get started: 基础入门
           How-to guides: 操作指南
           Technical reference: 技术参考
           Success stories: 成功案例
         pt:
+          Home: Início
           Get started: Primeiros passos
           How-to guides: Guias de instruções
           Technical reference: Referência técnica
           Success stories: Histórias de sucesso
         ja:
+          Home: ホーム
           Get started: スタート・ガイド
           How-to guides: チュートリアル
           Technical reference: 参考資料


### PR DESCRIPTION
@m-kuhn This PR is going to fix #346 partially. It is just for adding the word translation for `Home` tab name.  

I used translation software to add translations for `de`, `fr`, `it`, `pt`, `es` and `zh`. Could you double-check whether my translations are appropriate?

I tested every language locally. The following screenshot is for Japanese version.
![image](https://github.com/opengisch/QField-docs/assets/2639701/0ac743df-a6a0-4ff6-9b9f-73828484369c)