### PR TITLE
removing dead code

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -63,18 +63,6 @@ jobs:
         env:
           DEFAULT_LANGUAGE_ONLY: false
 
-      - name: Inject meta data to ensure proper font rendering for some translations
-        run: |
-          if [[ -d site/ja ]]
-          then
-            echo -e "social:\n  cards_layout_options:\n    font_family: Noto Sans JP" > site/ja/.meta.yml
-            echo "Successfully injected meta data into Japanese translation."
-          else
-            echo "*** Japanese translations not found in:"
-            echo "$(ls site)"
-            echo "*** Skipping this step."
-          fi
-
       - name: Deploy to GitHub Pages
         uses: JamesIves/github-pages-deploy-action@v4.2.2
         with:


### PR DESCRIPTION
2 issues:
- futile because by the time it's called the docs has already been built
- the approach is not compatible with the file-extension-based structure currently used (it would work only for the language-subdirectory structure approach, as per https://github.com/squidfunk/mkdocs-material/discussions/5704#discussioncomment-6435923.

More context: https://github.com/opengisch/QField-docs/issues/355#issuecomment-1730110069