### PR TITLE
Fix builds by disabling the mkdocs-insiders version

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -29,10 +29,10 @@ jobs:
       - name: Install Python requirements
         run: pip install -r requirements.txt
 
-      - name: Install Python requirements insiders
-        run: pip install -r requirements-insiders.txt
-        env:
-          MKDOCS_INSIDERS_TOKEN: ${{ secrets.MKDOCS_INSIDERS_TOKEN }}
+      # - name: Install Python requirements insiders
+      #   run: pip install -r requirements-insiders.txt
+      #   env:
+      #     MKDOCS_INSIDERS_TOKEN: ${{ secrets.MKDOCS_INSIDERS_TOKEN }}
 
       - name: Install Transifex client
         run: |

--- a/.github/workflows/zoho.yml
+++ b/.github/workflows/zoho.yml
@@ -24,7 +24,7 @@ jobs:
           MKDOCS_INSIDERS_TOKEN: ${{ secrets.MKDOCS_INSIDERS_TOKEN }}
         run: |
           pip install -r requirements.txt
-          pip install -r requirements-insiders.txt
+          # pip install -r requirements-insiders.txt
 
       - name: Generate Zoho authentication credentials and update Zoho
         env:

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -157,11 +157,11 @@ extra:
 plugins:
   - mkdocs-video
   - search
-  - social:
-      # See https://squidfunk.github.io/mkdocs-material/setup/setting-up-social-cards/
-      cards_color:
-        fill: "#72ad2e"
-        text: "#FFFFFF"
+  # - social:
+  #     # See https://squidfunk.github.io/mkdocs-material/setup/setting-up-social-cards/
+  #     cards_color:
+  #       fill: "#72ad2e"
+  #       text: "#FFFFFF"
   - i18n:
       default_language_only: !ENV [DEFAULT_LANGUAGE_ONLY, true]
       # FIX ME: Add autodetection to translation rates so that only languages

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -159,9 +159,9 @@ plugins:
   - search
   - social:
       # See https://squidfunk.github.io/mkdocs-material/setup/setting-up-social-cards/
-      cards_color:
-        fill: "#72ad2e"
-        text: "#FFFFFF"
+      cards_layout_options:
+        background_color: "#72ad2e"
+        color: "#FFFFFF"
   - i18n:
       default_language_only: !ENV [DEFAULT_LANGUAGE_ONLY, true]
       # FIX ME: Add autodetection to translation rates so that only languages

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -157,11 +157,11 @@ extra:
 plugins:
   - mkdocs-video
   - search
-  # - social:
-  #     # See https://squidfunk.github.io/mkdocs-material/setup/setting-up-social-cards/
-  #     cards_color:
-  #       fill: "#72ad2e"
-  #       text: "#FFFFFF"
+  - social:
+      # See https://squidfunk.github.io/mkdocs-material/setup/setting-up-social-cards/
+      cards_color:
+        fill: "#72ad2e"
+        text: "#FFFFFF"
   - i18n:
       default_language_only: !ENV [DEFAULT_LANGUAGE_ONLY, true]
       # FIX ME: Add autodetection to translation rates so that only languages

--- a/requirements-insiders.txt
+++ b/requirements-insiders.txt
@@ -1,1 +1,1 @@
-git+https://${MKDOCS_INSIDERS_TOKEN}@github.com/opengisch/mkdocs-material-insiders@425df60910d649d80505851dc2fd3d240cd65e73#egg=mkdocs-material
+git+https://${MKDOCS_INSIDERS_TOKEN}@github.com/opengisch/mkdocs-material-insiders@9.4.6-insiders-4.42.2#egg=mkdocs-material

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,6 @@ CairoSVG==2.7.1
 cryptography==41.0.4
 fancyboxmd==1.1.0
 mkdocs-material==9.4.6
-mkdocs-material-extensions==1.3
 mkdocs-static-i18n==1.1.1
 mkdocs-video==1.5.0
 PyGithub==2.1.1


### PR DESCRIPTION
This workaround should be in place until https://github.com/squidfunk/mkdocs-material/issues/6241 is fixed.

See an alternative solution in e54bce4b5e227fb2e5babc722b7c721478c1d7f6 that disables the social plugin.