### PR TITLE
Use deploy key

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -76,8 +76,9 @@ jobs:
           fi
 
       - name: Deploy to GitHub Pages
-        uses: JamesIves/github-pages-deploy-action@v4.2.2
+        uses: JamesIves/github-pages-deploy-action@v4
         with:
             branch: gh-pages
             clean: true
             folder: site
+            ssh-key: ${{ secrets.DEPLOY_TO_GH_PAGES_PRIVATE_KEY }}


### PR DESCRIPTION
To avoid specific users being the source of cron updates

Also updates the action to the latest v4, hopefully getting rid of some warnings about deprecated node versions and set-output usage