### PR TITLE
remove dependeny on frontmatter

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,4 +6,3 @@ mkdocs-static-i18n==1.1.1
 mkdocs-video==1.5.0
 PyGithub==2.1.1
 python-dotenv==1.0.0
-python-frontmatter==1.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,4 +5,3 @@ mkdocs-material==9.4.6
 mkdocs-static-i18n==1.1.1
 mkdocs-video==1.5.0
 PyGithub==2.1.1
-python-dotenv==1.0.0

--- a/utils/transifex_utils.py
+++ b/utils/transifex_utils.py
@@ -1,6 +1,6 @@
 import os
 import glob
-import frontmatter
+import re
 
 TX_ORGANIZATION = "opengisch"
 TX_PROJECT = "qfield-documentation"
@@ -27,12 +27,24 @@ def create_transifex_config():
             # Get relative path of file
             relative_path = os.path.relpath(file, start = root)
 
-            tx_slug = frontmatter.load(file).get('tx_slug', None)
+            tx_slugs = [re.match(r"^tx_slug: +(.*)", line) for line in open(file)]
+            tx_slugs = [t for t in tx_slugs if t]
 
-            if tx_slug:
-                print(f"Found file with tx_slug defined: {relative_path}, {tx_slug}")
+            if not tx_slugs:
+                print(f"No TX slug found for {relative_path}")
+
+            if len(tx_slugs) > 1:
+                print(f"More than 1 TX slug found for {relative_path}")
+
+            if tx_slugs:
+                tx_slug = tx_slugs[0].group(1)
+                print(
+                    f"Found file with tx_slug defined: `{relative_path}`, `{tx_slug}`"
+                )
                 f.write(f"[o:{TX_ORGANIZATION}:p:{TX_PROJECT}:r:{tx_slug}]\n")
-                f.write(f"file_filter = {''.join(relative_path.split('.')[:-2])}.<lang>.md\n")
+                f.write(
+                    f"file_filter = {''.join(relative_path.split('.')[:-2])}.<lang>.md\n"
+                )
                 f.write(f"source_file = {relative_path}\n")
                 f.write(f"source_lang = {TX_SOURCE_LANG}\n")
                 f.write(f"type = {TX_TYPE}\n\n")


### PR DESCRIPTION
not sure you want to do the same, but I dropped extra dependency on `frontmatter` (could not update it to a recent version on GH workflow)
I did this for signalo, and suggest to keep synchronized, but nothing required