### PR TITLE
Update pictures.en.md

### DIFF
--- a/documentation/how-to/pictures.en.md
+++ b/documentation/how-to/pictures.en.md
@@ -77,7 +77,7 @@ QField have an in-app drawing and sketching functionality enabling you to direct
 
 Some mobile devices will require for native camera mode to be turned off to enable geotagging.
 
-To enable geotagging in case your native OS camera does not support this functionality, follow these steps:
+To enable geotagging in case your native OS camera does not support this functionality or does not make this information available to QField, follow these steps:
 
 1.  In QField, go to the *settings* and make sure *Use native Camera* is
     deactivated


### PR DESCRIPTION
The current explanation is somewhat confusing, as the native camera of most smartphones is capable of geotagging, while the actual problem lies in not providing this information to QField (For example iOS devices). Most non technical users would think there native camera app can geotag images, so it should qualify. This clarification should help understanding that the transfer of this information is the crucial part.

See [#5532](https://github.com/opengisch/QField/issues/5532)