### PR TITLE
Remove use of trademark wording

### DIFF
--- a/documentation/how-to/standalone-datasets.en.md
+++ b/documentation/how-to/standalone-datasets.en.md
@@ -24,7 +24,7 @@ The supported vector formats are:
 The supported raster formats are:
 
 - GeoTIFF (.tif, .tiff);
-- Georeferenced PDF / GeoPDF (.pdf);
+- Geospatial PDF (.pdf);
 - JPEG2000 (.jp2);
 - JPEG (.jpg, .jpeg);
 - PNG (.png); and


### PR DESCRIPTION
Also aligns usage of geospatial PDF with what's been picked by gdal & QGIS.