### PR TITLE
Add missing plugins link within the technical reference's sidebar

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -99,6 +99,7 @@ nav:
       - reference/data-format.md
       - reference/exif.md
       - reference/expression_variables.md
+      - reference/plugins.md
       - QFieldCloud:
           - reference/qfieldcloud/workflow.md
           - reference/qfieldcloud/concepts.md


### PR DESCRIPTION
When doing a QField plugins framework presentation last week, I noticed a missing plugins link in the technical reference's sidebar:

![image](https://github.com/user-attachments/assets/8e737faa-211d-404c-97e9-82819a4e4246)

Without it, the technical plugins page is nearly impossible to find. This PR fixes that.