### PR TITLE
Mention firewall allowing minio port in architecture

### DIFF
--- a/documentation/reference/qfieldcloud/architecture.en.md
+++ b/documentation/reference/qfieldcloud/architecture.en.md
@@ -123,7 +123,7 @@ The data is stored on 4 **[`minio_data`]** volumes, as replication is enforced b
 
 Should be replaced by a proper S3-like Object Storage SaaS provider.
 
-If a `minio` is running, please make sure the host's firewall allows port `8009`, required by the `minio` service (or the port configured with the `MINIO_API_PORT` environment variable).
+If `minio` is running, please make sure the host's firewall allows port `8009`, required by the `minio` service (or the port configured with the `MINIO_API_PORT` environment variable).
 
 
 #### [`createbuckets`] Create Minio Buckets

--- a/documentation/reference/qfieldcloud/architecture.en.md
+++ b/documentation/reference/qfieldcloud/architecture.en.md
@@ -123,7 +123,7 @@ The data is stored on 4 **[`minio_data`]** volumes, as replication is enforced b
 
 Should be replaced by a proper S3-like Object Storage SaaS provider.
 
-If a minio is running, please make sure the host's firewall allows port `8009`, required by the `minio` service (or the port configured with the `MINIO_API_PORT` environment variable).
+If a `minio` is running, please make sure the host's firewall allows port `8009`, required by the `minio` service (or the port configured with the `MINIO_API_PORT` environment variable).
 
 
 #### [`createbuckets`] Create Minio Buckets

--- a/documentation/reference/qfieldcloud/architecture.en.md
+++ b/documentation/reference/qfieldcloud/architecture.en.md
@@ -123,6 +123,8 @@ The data is stored on 4 **[`minio_data`]** volumes, as replication is enforced b
 
 Should be replaced by a proper S3-like Object Storage SaaS provider.
 
+If a minio is running, please make sure the host's firewall allows port `8009`, required by the `minio` service (or the port configured with the `MINIO_API_PORT` environment variable).
+
 
 #### [`createbuckets`] Create Minio Buckets
 


### PR DESCRIPTION
Present in the README of the QFieldCloud repository (https://github.com/opengisch/QFieldCloud/blob/84994c9650e5d255d2208807cf388014d22a278b/README.md?plain=1#L53), could be interesting to have it here as well.