### PR TITLE
Removing third party tutorial from nav page tree

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -64,7 +64,6 @@ nav:
       - get-started/license.md
       - get-started/contribute.md
       - get-started/how-to-contribute-translation.md
-      - get-started/third-part-tutorials.md
   - How-to guides:
       - how-to/index.md
       - how-to/projects.md


### PR DESCRIPTION
As the file Markdown was removed this is no longer needed