### PR TITLE
The mkdocs.yml's nav object should not include '.en'

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -53,7 +53,7 @@ nav:
           - QFieldCloud:
               - get-started/tutorials/get-started-qfc.md
               - get-started/tutorials/advanced-setup-qfc.md
-              - get-started/tutorials/my-first-project.en.md
+              - get-started/tutorials/my-first-project.md
               - get-started/storage-qfc.md
           - QFieldSync:
               - get-started/tutorials/get-started-qfs.md
@@ -108,7 +108,7 @@ nav:
       - reference/exif.md
       - reference/expression_variables.md
       - reference/plugins.md
-      - reference/troubleshoot.en.md
+      - reference/troubleshoot.md
       - QFieldCloud:
           - reference/qfieldcloud/workflow.md
           - reference/qfieldcloud/concepts.md


### PR DESCRIPTION
Fixes:

<img width="890" height="410" alt="image" src="https://github.com/user-attachments/assets/0f06966d-8cd2-4564-8621-6f11becaa6f8" />

