### PR TITLE
Rework local docker image build and README

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,26 +1,41 @@
-# Setup Python dependencies
-FROM python:3.10-slim-bullseye
+# Setup dependencies
+FROM python:3.11-slim-bullseye
 RUN apt-get update && apt upgrade -y && \
-    apt install -y git curl && \
-    # Debian packages are way too old to be relied upon here
-    # hence turning to Python:
-    pip install pipenv --upgrade pip
+    apt-get update && \
+    apt-get install -y \
+        git \
+        curl \
+        libcairo2 \
+        libpango-1.0-0 \
+        libgdk-pixbuf-2.0-0 \
+        libffi-dev \
+        shared-mime-info \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
+
+# Debian packages are way too old to be relied upon here
+# hence turning to Python:
+RUN pip install --upgrade pip pipenv
 
 # Installing Python requirements
 WORKDIR /opt/app
+
+COPY requirements.txt ./
+
+ENV PIPENV_VENV_IN_PROJECT=0
+ENV PIPENV_SYSTEM=1
+
+RUN pipenv lock
+RUN pipenv install -r requirements.txt
+
 COPY . .
-ENV PIPENV_VENV_IN_PROJECT=1
-RUN pipenv install --three
 
 # Fetching and installing Transifex client
 RUN curl -o- https://raw.githubusercontent.com/transifex/cli/master/install.sh | bash
 
-# Token pass through for docker build --build-arg ...
-ARG tx_token
-ENV TX_TOKEN $tx_token
-
 # Setting up and fetch translations the docs
-RUN ./tx add --project qfield-documentation --file-filter 'documentation/<project_slug>.<resource_slug>/<lang>.<ext>' remote https://www.transifex.com/opengisch/qfield-documentation/dashboard/ && \
+RUN --mount=type=secret,id=tx_token,env=TX_TOKEN \
+    ./tx add --project qfield-documentation --file-filter 'documentation/<project_slug>.<resource_slug>/<lang>.<ext>' remote https://app.transifex.com/opengisch/qfield-documentation/dashboard/ && \
     ./tx pull --minimum-perc 10
 
 # Serving locally

--- a/README.md
+++ b/README.md
@@ -122,28 +122,33 @@ If you want to see the site in all the translations, in `.env` file set `BUILD_O
 
 
 #### Contribute
+
 Before committing, install [pre-commit](https://pre-commit.com/) to auto-format your contributions. You can install pre-commit for the current user with
 
-    pip install --user pre-commit
-    pre-commit install
-
+```sh
+pip install --user pre-commit
+pre-commit install
+```
 
 #### Testing your changes (on your local machine via Docker)
 
 Ensure [Docker](https://docs.docker.com/get-docker/) or [Podman](https://podman.io/getting-started/installation) is installed and set up as appropriate. If using Podman substitute `podman` for `docker` in the following steps.
 
 1. Clone this repository: git clone https://github.com/opengisch/QField-docs
-2. Build the container: `docker build . -t qfield-docs`
-3. Run it: `docker run -it -v ${PWD}/documentation:/opt/app/documentation -p 8000:8000 qfield-docs`
-4. Point your browser to the serving endpoint at http://localhost:8000.  <!-- markdown-link-check-disable-line -->
+2. Create or get a Transifex API token on `app.transifex.com`, and save it to a local `.transifexrc` file.
+3. Build the container: `docker build . -t qfield-docs --secret id=tx_token,src=.transifexrc`
+4. Run it: `docker run -it -v ${PWD}/documentation:/opt/app/documentation -p 8000:8000 qfield-docs`
+5. Point your browser to the serving endpoint at <http://localhost:8000>.  <!-- markdown-link-check-disable-line -->
 
 The server will automatically live-reload with any change made to the local `./documentation` directory.
 
 For inspecting the built documentation before serving you can instead run the container with:
 
-    docker run -it -p 8000:8000 --rm localhost/qfield-docs bash
-    source .venv/bin/activate
-    mkdocs build
+```sh
+docker run -it -p 8000:8000 --rm localhost/qfield-docs bash
+source .venv/bin/activate
+mkdocs build
+```
 
 The build output is available at `./site` inside of the container.
 
@@ -157,8 +162,7 @@ request](https://help.github.com/articles/using-pull-requests/).
 
 *Note: You will need to have a [Transifex account](https://transifex.com/) for this.*
 
-Navigate to our [Transifex
-project](https://explore.transifex.com/opengisch/)
+Navigate to our [Transifex project](https://explore.transifex.com/opengisch/)
 and click on the language you would like to translate. You will see a link
 `Join Team`. Click it and wait for approval (you will receive an email).
 


### PR DESCRIPTION
Basically the title : local docker build should now be okay, making use of layers caching as well as [docker secrets build](https://docs.docker.com/build/building/secrets/), recommended in the doc over `ARG` and `ENV`.

`PIPENV_VENV_IN_PROJECT=0` and `PIPENV_SYSTEM=1` is the best combination I could find to bascially make things work,