### PR TITLE
Delete requirements-insiders.txt

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -15,8 +15,6 @@ jobs:
   translations:
     runs-on: ubuntu-latest
     if: (github.event_name == 'schedule' && github.repository == 'opengisch/QField-docs') || (github.event_name != 'schedule')
-    env:
-      MKDOCS_INSIDERS_TOKEN: ${{ secrets.MKDOCS_INSIDERS_TOKEN }}
     steps:
       - uses: actions/checkout@v4
 
@@ -33,10 +31,6 @@ jobs:
           pip install -r requirements.txt
           pip install -r requirements-dev.txt
 
-      - name: Install Python requirements insiders
-        if: ${{ env.MKDOCS_INSIDERS_TOKEN != '' }}
-        run: pip install -r requirements-insiders.txt
-
       - name: Install Transifex client
         run: |
           curl -OL https://github.com/transifex/cli/releases/download/v1.6.10/tx-linux-amd64.tar.gz
@@ -46,7 +40,6 @@ jobs:
         run: ./utils/mkdocs_tx.py create_source
 
       - name: Configure Transifex
-        if: ${{ env.MKDOCS_INSIDERS_TOKEN != '' }}
         run: ./utils/transifex_utils.py
         env:
           TX_TOKEN: ${{ secrets.TX_TOKEN }}
@@ -64,7 +57,6 @@ jobs:
           cmd: yq '.plugins[] | .i18n.languages | select( . != null ) | map(.locale) | join(",")' mkdocs.yml
 
       - name: Pull translations from Transifex
-        if: ${{ env.MKDOCS_INSIDERS_TOKEN != '' }}
         run: |
           ./tx pull -t -l ${{ steps.get_langs.outputs.result }}
           ./tx status
@@ -72,7 +64,6 @@ jobs:
           TX_TOKEN: ${{ secrets.TX_TOKEN }}
 
       - name: Translate Mkdocs config
-        if: ${{ env.MKDOCS_INSIDERS_TOKEN != '' }}
         run: |
           ./utils/mkdocs_tx.py -s en update_config
           ./utils/mkdocs_tx_commit.sh

--- a/.github/workflows/zoho.yml
+++ b/.github/workflows/zoho.yml
@@ -20,11 +20,8 @@ jobs:
         run: pip install -r requirements.txt
 
       - name: Install dependencies
-        env:
-          MKDOCS_INSIDERS_TOKEN: ${{ secrets.MKDOCS_INSIDERS_TOKEN }}
         run: |
           pip install -r requirements.txt
-          # pip install -r requirements-insiders.txt
 
       - name: Generate Zoho authentication credentials and update Zoho
         env:

--- a/.github/workflows/zoho.yml
+++ b/.github/workflows/zoho.yml
@@ -19,10 +19,6 @@ jobs:
       - name: Install Python requirements
         run: pip install -r requirements.txt
 
-      - name: Install dependencies
-        run: |
-          pip install -r requirements.txt
-
       - name: Generate Zoho authentication credentials and update Zoho
         env:
           IS_PR: ${{ github.event_name == 'pull_request' }}

--- a/.markdown-link-check-config.json
+++ b/.markdown-link-check-config.json
@@ -12,5 +12,10 @@
       "pattern": ",[0-9]+px$",
       "replacement": ""
     }
+  ],
+  "ignorePatterns": [
+    {
+      "pattern": "^https://(www\\.)?kobotoolbox\\.org/?$"
+    }
   ]
 }

--- a/documentation/how-to/advanced-how-tos/xlsforms-plugin.en.md
+++ b/documentation/how-to/advanced-how-tos/xlsforms-plugin.en.md
@@ -10,7 +10,7 @@ This tool migrates all configurations from your form into a configured project a
 
 ## XLSForms
 
-XLSForms is a standard used by several survey products such as [ODK](https://getodk.org/) or [KoboToolbox](https://www.kobotoolbox.org/).
+XLSForms is a standard used by several survey products such as [ODK](https://getodk.org/) or [KoboToolbox](https://kobotoolbox.org/).
 XLSForms is built on a spreadsheet format using Excel as the standard.
 In simple terms a survey is made up of several "Questions" that can be presented in different formats (integer, text, lists etc.).
 To learn more about the standard please visit the [XLSForm reference website](https://xlsform.org/).

--- a/requirements-insiders.txt
+++ b/requirements-insiders.txt
@@ -1,1 +1,0 @@
-git+https://${MKDOCS_INSIDERS_TOKEN}@github.com/opengisch/mkdocs-material-insiders@9.5.17-insiders-4.53.5#egg=mkdocs-material

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 CairoSVG==2.9.0
 cryptography==46.0.7
 fancyboxmd==1.1.0
-mkdocs-material===9.5.17
+mkdocs-material===9.7.0
 mkdocs-static-i18n==1.2.0
 mkdocs-video==1.5.0


### PR DESCRIPTION
This PR remove all references mkdocs-material-insiders and bumps mkdocs-material to 9.7.0, the last ever  released version that now includes insiders too.

the github.com/squidfunk/mkdocs-material-insiders repo has been deleted as announced on May 1st thus our docs build fails.

see:  https://squidfunk.github.io/mkdocs-material/blog/2025/11/11/insiders-now-free-for-everyone/