### PR TITLE
Add ignore pattern for kobotoolbox.org links

### DIFF
--- a/.markdown-link-check-config.json
+++ b/.markdown-link-check-config.json
@@ -12,5 +12,10 @@
       "pattern": ",[0-9]+px$",
       "replacement": ""
     }
+  ],
+  "ignorePatterns": [
+    {
+      "pattern": "^https://kobotoolbox\\.org/?$"
+    }
   ]
 }

--- a/.markdown-link-check-config.json
+++ b/.markdown-link-check-config.json
@@ -15,7 +15,7 @@
   ],
   "ignorePatterns": [
     {
-      "pattern": "^https://kobotoolbox\\.org/?$"
+      "pattern": "^https://(www\\.)?kobotoolbox\\.org/?$"
     }
   ]
 }


### PR DESCRIPTION
kobotoolbox.org returns 403 to CI