### PR TITLE
add selfhosting documentation

### DIFF
--- a/documentation/reference/qfieldcloud/self_hosted/index.en.md
+++ b/documentation/reference/qfieldcloud/self_hosted/index.en.md
@@ -25,4 +25,3 @@ Follow the README and the documentation in that repository to set up and configu
 The documentation in this section covers administration through the built-in Django admin panel. Once your instance is running, see:
 
 - [Django administration interface](django_interface.md) — manage users, organisations, teams, projects, and secrets.
-

--- a/documentation/reference/qfieldcloud/self_hosted/index.en.md
+++ b/documentation/reference/qfieldcloud/self_hosted/index.en.md
@@ -1,0 +1,28 @@
+---
+title: QFieldCloud Self-Hosting
+tx_slug: documentation_reference_qfieldcloud_self_hosted
+---
+
+# QFieldCloud Self-Hosting
+
+!!! note
+    Most of this documentation describes QFieldCloud as offered at [app.qfield.cloud](https://app.qfield.cloud). That hosted service runs on the same open-source backend, but adds a polished web frontend and account, subscription, and payment management for the hosted offering. The hosted service helps fund ongoing development of QField and QFieldCloud.
+
+The full QFieldCloud backend is open source and production-ready. You can self-host it and get everything needed to work with QField. QFieldCloud also exposes a complete REST API, so you can build your own frontend or integrate it into existing systems. Contributions are welcome via the [contributor guide](https://github.com/opengisch/QFieldCloud#collaboration).
+
+Self-hosting gives you full control over data residency, user management, and configuration.
+
+## Installation
+
+Installation instructions, requirements, and configuration reference are maintained in the QFieldCloud source repository:
+
+[https://github.com/opengisch/QFieldCloud](https://github.com/opengisch/QFieldCloud)
+
+Follow the README and the documentation in that repository to set up and configure your self-hosted instance.
+
+## Administration via the Django admin panel
+
+The documentation in this section covers administration through the built-in Django admin panel. Once your instance is running, see:
+
+- [Django administration interface](django_interface.md) — manage users, organisations, teams, projects, and secrets.
+

--- a/documentation/reference/qfieldcloud/self_hosted/index.en.md
+++ b/documentation/reference/qfieldcloud/self_hosted/index.en.md
@@ -6,7 +6,7 @@ tx_slug: documentation_reference_qfieldcloud_self_hosted
 # QFieldCloud Self-Hosting
 
 !!! note
-    Most of this documentation describes QFieldCloud as offered at [app.qfield.cloud](https://app.qfield.cloud). That hosted service runs on the same open-source backend, but adds a polished web frontend and account, subscription, and payment management for the hosted offering. The hosted service helps fund ongoing development of QField and QFieldCloud.
+    Most of this documentation site describes QFieldCloud as offered at [app.qfield.cloud](https://app.qfield.cloud). That hosted service runs on the same open-source backend, but adds a polished web frontend as well as account, subscription, and payment management for the hosted offering. Revenues from the hosted service helps fund ongoing development of QField and QFieldCloud.
 
 The full QFieldCloud backend is open source and production-ready. You can self-host it and get everything needed to work with QField. QFieldCloud also exposes a complete REST API, so you can build your own frontend or integrate it into existing systems. Contributions are welcome via the [contributor guide](https://github.com/opengisch/QFieldCloud#collaboration).
 

--- a/documentation/reference/qfieldcloud/self_hosted/index.en.md
+++ b/documentation/reference/qfieldcloud/self_hosted/index.en.md
@@ -8,7 +8,7 @@ tx_slug: documentation_reference_qfieldcloud_self_hosted
 !!! note
     Most of this documentation site describes QFieldCloud as offered at [app.qfield.cloud](https://app.qfield.cloud). That hosted service runs on the same open-source backend, but adds a polished web frontend as well as account, subscription, and payment management for the hosted offering. Revenues from the hosted service helps fund ongoing development of QField and QFieldCloud.
 
-The full QFieldCloud backend is open source and production-ready. You can self-host it and get everything needed to work with QField. QFieldCloud also exposes a complete REST API, so you can build your own frontend or integrate it into existing systems. Contributions are welcome via the [contributor guide](https://github.com/opengisch/QFieldCloud#collaboration).
+The full QFieldCloud backend is open source and production-ready. You can self-host it and get everything needed to work with QField and QFieldSync. QFieldCloud also exposes a complete REST API, so you can build your own frontend or integrate it into existing systems. Contributions are welcome via the [contributor guide](https://github.com/opengisch/QFieldCloud#collaboration).
 
 Self-hosting gives you full control over data residency, user management, and configuration.
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -116,11 +116,6 @@ nav:
           - how-to/advanced-how-tos/qr-codes.md
   - Technical reference:
       - reference/index.md
-      - reference/data-format.md
-      - reference/exif.md
-      - reference/expression_variables.md
-      - reference/plugins.md
-      - reference/troubleshoot.md
       - QFieldCloud:
           - reference/qfieldcloud/workflow.md
           - reference/qfieldcloud/projects.md
@@ -133,8 +128,14 @@ nav:
           - reference/qfieldcloud/api.md
           - reference/qfieldcloud/system.md
           - reference/qfieldcloud/sdk.md
-          - Managing Organization on Self-Hosted:
-              - reference/qfieldcloud/self_hosted/django_interface.md
+      - Self-Hosting QFieldCloud:
+          - reference/qfieldcloud/self_hosted/index.md
+          - reference/qfieldcloud/self_hosted/django_interface.md
+      - reference/plugins.md
+      - reference/data-format.md
+      - reference/exif.md
+      - reference/expression_variables.md
+      - reference/troubleshoot.md
   - Success stories:
       - success-stories/index.md
       - success-stories/ecological-surveying.md


### PR DESCRIPTION
Adds an index page for the QFieldCloud self-hosting section of the docs and clarifies that most QFieldCloud documentation describes the hosted service at app.qfield.cloud, which runs on the same open-source backend but adds a polished frontend and subscription/payment management

existing urls are unchanged and https://docs.qfield.org/reference/qfieldcloud/self_hosted/ is introduced