### PR TITLE
jobs: display jobs logs retention period

### DIFF
--- a/documentation/reference/qfieldcloud/jobs.en.md
+++ b/documentation/reference/qfieldcloud/jobs.en.md
@@ -23,6 +23,7 @@ Jobs have access to [project secrets](projects.md#secrets).
 !!! warning
     - Any of the triggering conditions described on this page might change without notice.
     - All jobs must finish within 10 minutes or they will result in a timeout error and will be terminated.
+    - Jobs logs are stored for a period of 90 days, after that time the logs are automatically deleted.
 
 !!! info
     If you are looking for technical details how Jobs work, check the [Job Queue documentation](./architecture.md#job-queue).


### PR DESCRIPTION
Anticipating this upcoming dev: Jobs logs will automatically be deleted after a 90 days retention period.  
Question about _when_ this doc PR should be merged though, could be a good idea to have it documented before the Jobs logs cleaning is effective.