### PR TITLE
Fix github workflow problems

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -43,12 +43,13 @@ jobs:
         run: ./utils/mkdocs_tx.py create_source
 
       - name: Configure Transifex
+        if: env.TX_TOKEN != ''
         run: ./utils/transifex_utils.py
         env:
           TX_TOKEN: ${{ secrets.TX_TOKEN }}
 
       - name: Push source files to Transifex
-        if: contains(fromJSON('["push", "workflow_dispatch", "schedule"]'), github.event_name)
+        if: env.TX_TOKEN != '' && contains(fromJSON('["push", "workflow_dispatch", "schedule"]'), github.event_name)
         run: ./tx push
         env:
           TX_TOKEN: ${{ secrets.TX_TOKEN }}
@@ -60,6 +61,7 @@ jobs:
           cmd: yq '.plugins[] | .i18n.languages | select( . != null ) | map(.locale) | join(",")' mkdocs.yml
 
       - name: Pull translations from Transifex
+        if: env.TX_TOKEN != ''
         run: |
           ./tx pull -t -l ${{ steps.get_langs.outputs.result }}
           ./tx status
@@ -67,6 +69,7 @@ jobs:
           TX_TOKEN: ${{ secrets.TX_TOKEN }}
 
       - name: Translate Mkdocs config
+        if: env.GITHUB_TOKEN != ''
         run: |
           ./utils/mkdocs_tx.py -s en update_config
           ./utils/mkdocs_tx_commit.sh

--- a/utils/push_to_zoho.py
+++ b/utils/push_to_zoho.py
@@ -17,6 +17,10 @@ category_map = {
 }
 
 
+class SkipArticleError(Exception):
+    pass
+
+
 def extract_path(paths: list[str] | str) -> list[str] | str:
     # extract paths from a list of dict
     flat_paths = []
@@ -59,7 +63,15 @@ def convert_md(path: str) -> tuple[str, str, str]:
     if len(parts) != 3:
         raise ValueError("Markdown file {} seems to miss an header".format(path))
     _, header, body = parts
-    if not body.strip().startswith("# "):
+    stripped_body = body.strip()
+    if not stripped_body.startswith("# "):
+        # Redirect-only pages intentionally do not contain a markdown title.
+        if re.search(
+            r'<meta\s+http-equiv=["\']refresh["\']', stripped_body, flags=re.IGNORECASE
+        ):
+            raise SkipArticleError(
+                "Skipping redirect-only markdown file {}".format(path)
+            )
         raise ValueError("Markdown file {} seems to miss a # title".format(path))
     body = "{}{}".format(docs_url_warning, body)
 
@@ -231,7 +243,10 @@ def main():
                 path = "documentation/{}.en.md".format(path[:-3])
                 if os.path.exists(path):
                     print("Processing: ", path)
-                    push_article(category_title, path, headers, article_map)
+                    try:
+                        push_article(category_title, path, headers, article_map)
+                    except SkipArticleError as err:
+                        print(err)
                 else:
                     raise FileNotFoundError("File missing: ", path)
 


### PR DESCRIPTION
Stabilizes github workflow problems

- When secrets are not available, do not run tx etc steps that require secrets
- Gracefully skip redirect pages in zoho sync, up to now they failed because they have no header and they are not needed on zoho