### PR TITLE
Update QFieldCloud architecture reference for self-hosters

### DIFF
--- a/documentation/reference/qfieldcloud/architecture.en.md
+++ b/documentation/reference/qfieldcloud/architecture.en.md
@@ -23,9 +23,13 @@ See an interactive version of [the drawing above](https://excalidraw.com/#json=7
 #### `[nginx]` Reverse proxy
 
 The reverse proxy that sits in front of QFieldCloud.
-Hard requirement on [`nginx`](https://nginx.org/en/) for this purpose as the [`X-Accel-Redirect` HTTP header](https://nginx.org/en/docs/http/ngx_http_core_module.html#internal) is heavily used in production to serve files directly from the **[minio] File Storage**.
+Hard requirement on [`nginx`](https://nginx.org/en/) for this purpose as the [`X-Accel-Redirect` HTTP header](https://nginx.org/en/docs/http/ngx_http_core_module.html#internal) is heavily used in production to serve files directly from the **[`rustfs`] File Storage**, or from whichever Object Storage is configured in the `STORAGES` environment variable.
 
 Requires a SSL certificate to be present - self-signed, Let's Encrypt or other.
+
+!!! warning
+    Because files are served with `X-Accel-Redirect` and a presigned URL, the Object Storage endpoint must be resolvable and TLS-valid **from within the `[nginx]` Reverse proxy container**, not only from the **[`app`] QFieldCloud App**.
+    If your Object Storage uses a certificate signed by an internal certificate authority, mount that authority in the `custom_ca_certificates` volume.
 
 
 #### `[app]` QFieldCloud App
@@ -111,24 +115,35 @@ Contains all static assets such as fonts, CSS, JS or image files.
 The default location for User uploaded files. It should **never** be used.
 
 
-### Development services
+### Standalone services
 
-The following containers are available only for local development purposes and **should not** be used in production, as these services are not monitored, backed-up and generally designed for critical usage within the stack.
+The following containers are defined in `docker-compose.override.standalone.yml` and are provided so that a fresh checkout runs out of the box.
+They are **not** part of the application itself and **should not** be used in production, as these services are not monitored, backed-up and generally designed for critical usage within the stack.
+
+Each of them is meant to be replaced by infrastructure you already operate, see [Replacing the standalone services](#replacing-the-standalone-services).
+Note that replacing a *container* is not the same thing as replacing a *storage backend*: the S3 and WebDAV backends used by these containers are both production-grade backends of the **[`app`] QFieldCloud App**.
 
 
-#### [`minio`] File Storage
+#### [`rustfs`] File Storage
 
 Local Object Storage (S3-like) used for development.
-The data is stored on 4 **[`minio_data`]** volumes, as replication is enforced by `minio`.
+The data is stored on the single **[`rustfs_data`]** volume.
 
-Should be replaced by a proper S3-like Object Storage SaaS provider.
+Should be replaced by a proper S3-like Object Storage SaaS provider, or by any S3-compatible service you already run, see [Using an existing S3 service](#using-an-existing-s3-service).
 
-If `minio` is running, please make sure the host's firewall allows port `8009`, required by the `minio` service (or the port configured with the `MINIO_API_PORT` environment variable).
+If `rustfs` is running, please make sure the host's firewall allows the ports configured with the `OBJECT_STORAGE_API_PORT` (`8009` by default) and `OBJECT_STORAGE_BROWSER_PORT` (`8010` by default) environment variables.
+The credentials are set with `OBJECT_STORAGE_ROOT_USER` and `OBJECT_STORAGE_ROOT_PASSWORD`.
+
+!!! info
+    Up to QFieldCloud `v26.3` this service was provided by [`minio`](https://min.io/), stored its data on four `minio_data` volumes and was configured with the `MINIO_*` environment variables.
+    Deployments upgrading from an older version should rename the `MINIO_*` variables to their `OBJECT_STORAGE_*` counterparts in their `.env` file.
 
 
-#### [`createbuckets`] Create Minio Buckets
+#### [`createbuckets`] Create Object Storage buckets
 
-Single shot container to create the required buckets on the Object Storage under **[`minio`] File Storage**.
+Single shot container to create the required buckets on the Object Storage under **[`rustfs`] File Storage**.
+
+It declares a `depends_on` condition on the **[`rustfs`] File Storage**, therefore the two services can only be disabled together.
 
 
 #### [`webdav`] Alternative File Storage
@@ -137,12 +152,11 @@ Local WebDAV storage used for development, using WebDAV protocol and specificati
 
 The data is stored on the **[`webdav_data`]** volume.
 
-Can alternatively be used in place of the `minio` File Storage for storing the files. Can optionally be used for storing only attachments on it.
-
 !!! info
     The webdav storage is optional, it is not a requirement for the system to work properly.
 
-If used, the webdav storage service should be replaced by a proper WebDAV server, e.g. NextCloud.
+This container is a development convenience and should be replaced by a proper WebDAV server, e.g. NextCloud.
+The WebDAV *backend* it exercises is however a production storage backend, see [Choosing a file storage backend](#choosing-a-file-storage-backend).
 
 #### [`db`] App PostgreSQL
 
@@ -160,17 +174,9 @@ Local mailing server to handle emails being sent, such as registration activatio
 Should be replaced by a proper email SaaS provider that supports SMTP protocol.
 
 
-#### [`geodb`] GeoDB PostgreSQL
+#### [`rustfs_data`]
 
-!!! warning
-    Deprecated, might be removed at any time.
-
-Stores dynamically created user PostGIS databases.
-
-
-#### [`minio_data`]
-
-Stores data for the **[`minio`] S3 service**.
+Stores data for the **[`rustfs`] S3 service**.
 
 
 #### [`webdav_data`]
@@ -188,12 +194,66 @@ Stores data for **[`db`] App PostgreSQL**.
 Stores data for **[`smtpdev`] Mailing Server**.
 
 
-#### [`geodb_data`]
+### Removed services
+
+#### [`geodb`] GeoDB PostgreSQL
+
+Removed in QFieldCloud `v25.27`.
+It used to store dynamically created user PostGIS databases, together with its **[`geodb_data`]** volume.
+
+When upgrading an instance created before `v25.27`:
+
+- restart the stack with `--remove-orphans` so that the orphaned `geodb` container is dropped;
+- remove all the `GEODB_*` variables from your `.env` file;
+- be aware that the migration permanently deletes the `core_geodb` table and its contents. Back it up beforehand if you still need the data.
+
+User PostGIS databases are now provided by your own PostGIS instance, made available to projects through a `pg_service` [secret](secrets.md).
+The secret is injected in the ephemeral **[`qgis`] Worker** as the `PGSERVICE_FILE_CONTENTS` environment variable and written to a `pg_service.conf` file by the Worker's entrypoint.
+
+
+## Replacing the standalone services
+
+The **[`app`] QFieldCloud App** does not know whether its dependencies run as containers of the stack or as external infrastructure, and the base `docker-compose.yml` file defines only the application itself: `app`, `nginx`, `worker_wrapper`, `qgis3`, `qgis4`, `memcached`, `ofelia`, `certbot`, `mkcert` and `mirror_transformation_grids`.
+
+Every dependency - `db`, `rustfs`, `createbuckets`, `webdav` and `smtp4dev` - comes from `docker-compose.override.standalone.yml`, and only from there.
+
+None of the application services declares a `depends_on` on them: they are wired exclusively through the `POSTGRES_*`, `STORAGES` and `EMAIL_*` environment variables.
+Therefore, replacing a standalone service is only a matter of pointing those variables somewhere else, and then either:
+
+- removing `docker-compose.override.standalone.yml` from the `COMPOSE_FILE` environment variable, to replace all of them at once; or
+- adding `profiles: [donotstart]` to the individual services you want to disable.
+
+The only exception is the **[`createbuckets`] Create Object Storage buckets** container, which declares a `depends_on` on the **[`rustfs`] File Storage**.
+Those two must be disabled together, otherwise Docker Compose refuses to start the project with `service "createbuckets" depends on undefined service "rustfs"`.
+
+
+### Choosing a file storage backend
+
+The `STORAGES` environment variable selects the backend used to store project files.
+Two backends are supported in production:
+
+- an S3-compatible Object Storage, see [Using an existing S3 service](#using-an-existing-s3-service);
+- a WebDAV server, e.g. NextCloud. A configuration example is available in the `.env.example` file of the QFieldCloud repository.
+
+Both backends can be combined, for example by keeping project files on S3 and storing only the attachments on WebDAV.
+The WebDAV backend is the only one that supports `STORAGE_PROJECT_DEFAULT_ATTACHMENTS_VERSIONED=0`, which is a valid reason to pick it for attachments that do not need to be versioned.
+
+
+### Using an existing S3 service
+
+Any S3-compatible service can be used, as long as the **[`nginx`] Reverse proxy** can reach its endpoint, see the warning in the [`[nginx]` Reverse proxy](#nginx-reverse-proxy) section.
+
+The **[`createbuckets`] Create Object Storage buckets** container additionally requires the target service to implement:
+
+- bucket creation;
+- bucket policies, to make the `users` prefix publicly readable;
+- bucket versioning.
+
+Not every S3 implementation provides all three, therefore creating the bucket by hand and disabling the **[`createbuckets`] Create Object Storage buckets** container is a supported path.
 
 !!! warning
-    Deprecated, might be removed at any time.
-
-Stores data for **[`geodb`] GeoDB PostgreSQL**.
+    File versions of the current `filestorage` Django app are handled at application level and do not require S3 bucket versioning, whereas the legacy storage code path does rely on it.
+    An Object Storage without bucket versioning is therefore only usable by instances whose projects have all been migrated to the current `filestorage` app, and it comes at the cost of the soft delete that bucket versioning provides.
 
 
 ## Job Queue


### PR DESCRIPTION
Fixes #783.

  Following @beanzmo's invitation, here are the corrections to architecture.en.md covering the five points of the issue. Everything is checked
  against opengisch/QFieldCloud@master and the release tags.

  1. minio → rustfs — the service, its single rustfs_data volume and the OBJECT_STORAGE_* variables are documented, with a note for
  deployments upgrading from an older version. The stale references in [nginx], [createbuckets] and the volumes list are fixed too. The switch
  landed in #1453 and was first released in v26.4 (v26.3 still ships minio).

  2. geodb removed, not deprecated — moved to a new "Removed services" section stating v25.27, with the upgrade steps from #1379: restart with
  --remove-orphans, drop the GEODB_* variables, and a warning that the migration permanently deletes core_geodb. It also states what replaces
  it: your own PostGIS reached through a pg_service secret, with a link to secrets.md.

  3. webdav — "Development services" is renamed "Standalone services", and the section now distinguishes the development container from the
  production backend. The QfcWebDavStorage backend and the STORAGE_PROJECT_DEFAULT_ATTACHMENTS_VERSIONED=0 case are covered in the new section
  below.

  4. New section "Replacing the standalone services" — what docker-compose.yml defines versus what docker-compose.override.standalone.yml
  adds, that the dependencies are wired through POSTGRES_* / STORAGES / EMAIL_* and not through depends_on, and the two ways to disable them
  (COMPOSE_FILE, or profiles: [donotstart]). The createbuckets → rustfs depends_on is called out as the one exception, since Compose otherwise
  refuses the project outright.

  5. Sub-section "Using an existing S3 service" — the three capabilities createbuckets.py requires (bucket creation, bucket policies for the
  public users prefix, bucket versioning), that creating the bucket by hand and disabling the container is a supported path, and a warning
  about the legacy code path and the loss of application-level soft delete without versioning. The consequence of X-Accel-Redirect is also
  spelled out under [nginx]: the endpoint must resolve and be TLS-valid from within the nginx container, with a pointer to
  custom_ca_certificates.

  Happy to adjust the scope, split this up, or reword anything — in particular if you would rather see points 4 and 5 live in the self-hosted
  section than on the architecture page.

  One thing I did not touch: qfc_server_architecture_light.svg still labels minio and geodb. It is exported from your Excalidraw drawing, so
  it is probably easier for you to regenerate than for me to patch the SVG by hand.