### PR TITLE
open external links in new tab

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -200,7 +200,8 @@ plugins:
       cards_layout_options:
         background_color: "#72ad2e"
         color: "#FFFFFF"
-  - open-in-new-tab
+  - open-in-new-tab:
+      add_icon: true
   - i18n:
       build_only_locale: !ENV [BUILD_ONLY_LOCALE]
       # FIX ME: Add autodetection to translation rates so that only languages

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -200,6 +200,7 @@ plugins:
       cards_layout_options:
         background_color: "#72ad2e"
         color: "#FFFFFF"
+  - open-in-new-tab
   - i18n:
       build_only_locale: !ENV [BUILD_ONLY_LOCALE]
       # FIX ME: Add autodetection to translation rates so that only languages

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,5 +2,6 @@ CairoSVG==2.9.0
 cryptography==50.0.0
 fancyboxmd==1.1.0
 mkdocs-material===9.7.7
+mkdocs-open-in-new-tab==1.0.8
 mkdocs-static-i18n==1.2.0
 mkdocs-video==1.5.0


### PR DESCRIPTION
title is pretty clear :)

adds https://pypi.org/project/mkdocs-open-in-new-tab/ as dependency 

The automatic opening of links in a new tab is a common feature of modern websites. It is also a good practice for accessibility. However, it is not a default behavior of Markdown. This plugin adds a JavaScript code to your website that opens external links and PDFs in a new tab.